### PR TITLE
allow users to be logged on multiple devices

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -46,7 +46,7 @@ security:
                 secret: '%kernel.secret%'
                 lifetime: 2629800 # 1 month in seconds
                 always_remember_me: true
-                signature_properties: ['email', 'updatedAt']
+                signature_properties: ['id', 'email', 'enabled']
                 secure: true
                 httponly: true
 


### PR DESCRIPTION
fix #106 

removing the updatedAt field from signature properties, because everytime a user logs in with google or facebook we sync their name and picture so the updatedAt field updates as well and... the remember me cookie was deactivated at every new login