### PR TITLE
Block reviews containing frequent profanity/insults (EN/FR)

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -1,6 +1,7 @@
 monolog:
     channels:
         - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
+        - moderation # Review moderation events (e.g. blocked-word submissions), kept out of the fingers_crossed buffer so they always reach disk
 
 when@dev:
     monolog:
@@ -27,11 +28,16 @@ when@test:
                 action_level: error
                 handler: nested
                 excluded_http_codes: [404]
-                channels: ['!event']
+                channels: ['!event', '!moderation']
             nested:
                 type: stream
                 path: '%kernel.logs_dir%/%kernel.environment%.log'
                 level: debug
+            moderation:
+                type: stream
+                path: '%kernel.logs_dir%/moderation.log'
+                level: info
+                channels: [moderation]
 
 when@prod:
     monolog:
@@ -42,7 +48,13 @@ when@prod:
                 handler: main_grouped
                 excluded_http_codes: [404, 405]
                 buffer_size: 50 # How many messages should be saved? Prevent memory leaks
-                channels: ['!event', '!deprecation']
+                channels: ['!event', '!deprecation', '!moderation']
+            moderation:
+                type: rotating_file
+                path: '%kernel.logs_dir%/moderation.log'
+                level: info
+                max_files: 30
+                channels: [moderation]
             main_grouped:
                 type: group
                 members: [file, notifier]

--- a/src/Entity/RiddenCoaster.php
+++ b/src/Entity/RiddenCoaster.php
@@ -39,6 +39,7 @@ class RiddenCoaster
     private float $value = 0.0;
 
     #[ORM\Column(type: Types::TEXT, nullable: true)]
+    #[CaptainConstraints\NoBlockedWords]
     private ?string $review = null;
 
     #[ORM\Column(type: Types::STRING, length: 5)]

--- a/src/Entity/RiddenCoaster.php
+++ b/src/Entity/RiddenCoaster.php
@@ -39,7 +39,7 @@ class RiddenCoaster
     private float $value = 0.0;
 
     #[ORM\Column(type: Types::TEXT, nullable: true)]
-    #[CaptainConstraints\NoBlockedWords]
+    #[CaptainConstraints\NoBlockedWords(groups: ['review_text'])]
     private ?string $review = null;
 
     #[ORM\Column(type: Types::STRING, length: 5)]

--- a/src/Form/Type/ReviewType.php
+++ b/src/Form/Type/ReviewType.php
@@ -108,6 +108,7 @@ class ReviewType extends AbstractType
             [
                 'data_class' => RiddenCoaster::class,
                 'locales' => [],
+                'validation_groups' => ['Default', 'review_text'],
             ]
         );
     }

--- a/src/Validator/Constraints/BlockedWordList.php
+++ b/src/Validator/Constraints/BlockedWordList.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator\Constraints;
+
+/**
+ * Words with no legitimate non-insulting use in a coaster review, chosen for
+ * real frequency in the review corpus (English/French only) rather than
+ * theoretical coverage. See
+ * docs/superpowers/specs/2026-08-16-slur-and-profanity-block-design.md
+ * for the data behind this list and why other candidates (identity slurs,
+ * "con", "retard", ES/DE words) were deliberately excluded.
+ */
+final class BlockedWordList
+{
+    /**
+     * Regex alternatives, matched with word boundaries (case-insensitive).
+     * `\w*` stems catch common inflections (fuck/fucking/fucker/fucked).
+     * "salope" has no `\w*` suffix deliberately: "salopette" (French for
+     * dungarees) is an innocent word that starts with the same letters.
+     *
+     * @var list<string>
+     */
+    private const array PATTERNS = [
+        'fuck\w*',
+        'putain',
+        'goddamn\w*',
+        'bitch\w*',
+        'connard[e]?s?',
+        'asshole\w*',
+        'salope',
+    ];
+
+    public static function matches(string $text): bool
+    {
+        if ('' === $text) {
+            return false;
+        }
+
+        $regex = '/\b(?:'.implode('|', self::PATTERNS).')\b/iu';
+
+        return 1 === preg_match($regex, $text);
+    }
+}

--- a/src/Validator/Constraints/BlockedWordList.php
+++ b/src/Validator/Constraints/BlockedWordList.php
@@ -40,6 +40,15 @@ final class BlockedWordList
 
         $regex = '/\b(?:'.implode('|', self::PATTERNS).')\b/iu';
 
-        return 1 === preg_match($regex, $text);
+        $result = preg_match($regex, $text);
+
+        // preg_match() returns false (not 0) on malformed UTF-8 with the /u
+        // modifier. Fail closed (treat as blocked) rather than silently
+        // letting unparseable input through.
+        if (false === $result) {
+            return true;
+        }
+
+        return 1 === $result;
     }
 }

--- a/src/Validator/Constraints/NoBlockedWords.php
+++ b/src/Validator/Constraints/NoBlockedWords.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+class NoBlockedWords extends Constraint
+{
+    public string $message = 'blocked_words.review';
+}

--- a/src/Validator/Constraints/NoBlockedWordsValidator.php
+++ b/src/Validator/Constraints/NoBlockedWordsValidator.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator\Constraints;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class NoBlockedWordsValidator extends ConstraintValidator
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof NoBlockedWords) {
+            throw new UnexpectedTypeException($constraint, NoBlockedWords::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!\is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        if (BlockedWordList::matches($value)) {
+            $this->logger->info('Review submission blocked: contains a blocked word', [
+                'review_text' => $value,
+            ]);
+
+            $this->context->buildViolation($constraint->message)
+                ->addViolation();
+        }
+    }
+}

--- a/src/Validator/Constraints/NoBlockedWordsValidator.php
+++ b/src/Validator/Constraints/NoBlockedWordsValidator.php
@@ -11,8 +11,16 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class NoBlockedWordsValidator extends ConstraintValidator
 {
+    /**
+     * Injected via Symfony/MonologBundle's parameter-name channel autowiring:
+     * a constructor argument named "$moderationLogger" resolves to the
+     * "moderation" monolog channel (see config/packages/monolog.yaml),
+     * which has its own handler outside the main fingers_crossed buffer so
+     * these info-level records reach disk in prod instead of being
+     * silently discarded.
+     */
     public function __construct(
-        private readonly LoggerInterface $logger,
+        private readonly LoggerInterface $moderationLogger,
     ) {
     }
 
@@ -31,7 +39,13 @@ class NoBlockedWordsValidator extends ConstraintValidator
         }
 
         if (BlockedWordList::matches($value)) {
-            $this->logger->info('Review submission blocked: contains a blocked word', [
+            // The validator only ever sees the raw string value being
+            // validated (it has no access to the request, the entity, or
+            // the current user), so the log context is limited to the
+            // review text itself — there's no user_id/coaster_id available
+            // here without a larger refactor of how this constraint is
+            // invoked.
+            $this->moderationLogger->info('Review submission blocked: contains a blocked word', [
                 'review_text' => $value,
             ]);
 

--- a/templates/Review/form.html.twig
+++ b/templates/Review/form.html.twig
@@ -68,6 +68,7 @@
       <div class="form-group">
         {{ form_label(form.review, "", {'label_attr': {'class': 'control-label'}}) }}
         {{ form_widget(form.review, {'attr': {'class': 'form-control', 'cols': '5', 'rows': '5'}}) }}
+        {{ form_errors(form.review) }}
       </div>
       <div class="form-group">
         {{ form_label(form.language, "", {'label_attr': {'class': 'control-label'}}) }}

--- a/tests/Config/MonologConfigTest.php
+++ b/tests/Config/MonologConfigTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Config;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Regression test for the whole-branch review finding: NoBlockedWordsValidator
+ * logs at "info" level, but the "main" handler in both when@prod and when@test
+ * is a fingers_crossed handler with action_level: error and no
+ * passthru_level — meaning an info record is buffered and silently dropped
+ * unless an error happens in the same request. These assertions can't run a
+ * real kernel/monolog stack without much heavier test infrastructure than
+ * this project currently has (no WebTestCase/KernelTestCase usage exists),
+ * so this is a config-level assertion that the "moderation" channel has its
+ * own non-buffering handler and is excluded from the fingers_crossed "main"
+ * handler in both environments.
+ */
+class MonologConfigTest extends TestCase
+{
+    private const string CONFIG_PATH = __DIR__.'/../../config/packages/monolog.yaml';
+
+    /** @return array<string, mixed> */
+    private function parsedConfig(): array
+    {
+        return Yaml::parseFile(self::CONFIG_PATH);
+    }
+
+    public function testModerationChannelIsDeclared(): void
+    {
+        $config = $this->parsedConfig();
+
+        $this->assertContains('moderation', $config['monolog']['channels']);
+    }
+
+    /** @return iterable<string, array{0: string}> */
+    public static function environmentProvider(): iterable
+    {
+        yield 'test' => ['when@test'];
+        yield 'prod' => ['when@prod'];
+    }
+
+    /** @dataProvider environmentProvider */
+    public function testMainFingersCrossedHandlerExcludesModerationChannel(string $envKey): void
+    {
+        $config = $this->parsedConfig();
+        $main = $config[$envKey]['monolog']['handlers']['main'];
+
+        $this->assertSame('fingers_crossed', $main['type']);
+        $this->assertContains('!moderation', $main['channels']);
+    }
+
+    /** @dataProvider environmentProvider */
+    public function testModerationHandlerWritesInfoLevelOutsideFingersCrossedBuffer(string $envKey): void
+    {
+        $config = $this->parsedConfig();
+        $handlers = $config[$envKey]['monolog']['handlers'];
+
+        $this->assertArrayHasKey('moderation', $handlers, "Expected a dedicated 'moderation' handler in {$envKey}");
+
+        $moderationHandler = $handlers['moderation'];
+
+        $this->assertNotSame('fingers_crossed', $moderationHandler['type'], 'Moderation handler must not itself be a buffering fingers_crossed handler');
+        $this->assertSame('info', $moderationHandler['level']);
+        $this->assertSame(['moderation'], $moderationHandler['channels']);
+    }
+}

--- a/tests/Entity/RiddenCoasterValidationTest.php
+++ b/tests/Entity/RiddenCoasterValidationTest.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace App\Tests\Entity;
 
+use App\Entity\Coaster;
 use App\Entity\RiddenCoaster;
+use App\Entity\User;
 use App\Validator\Constraints\NoBlockedWordsValidator;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\ContainerConstraintValidatorFactory;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -19,8 +23,21 @@ class RiddenCoasterValidationTest extends TestCase
 
     protected function setUp(): void
     {
+        // Stub out doctrine's UniqueEntity validator (service id
+        // "doctrine.orm.validator.unique", declared class-level on
+        // RiddenCoaster): it needs a real ManagerRegistry/EntityManager,
+        // which these unit tests don't have. It's irrelevant to what's
+        // under test here (the NoBlockedWords group scoping), so it's
+        // stubbed to never flag a violation.
+        $noopValidator = new class extends ConstraintValidator {
+            public function validate(mixed $value, Constraint $constraint): void
+            {
+            }
+        };
+
         $validatorLocator = new ServiceLocator([
             NoBlockedWordsValidator::class => static fn (): NoBlockedWordsValidator => new NoBlockedWordsValidator(new NullLogger()),
+            'doctrine.orm.validator.unique' => static fn () => $noopValidator,
         ]);
 
         $this->validator = Validation::createValidatorBuilder()
@@ -34,7 +51,8 @@ class RiddenCoasterValidationTest extends TestCase
         $violations = $this->validator->validatePropertyValue(
             RiddenCoaster::class,
             'review',
-            'This coaster is fucking amazing'
+            'This coaster is fucking amazing',
+            ['review_text']
         );
 
         $this->assertCount(1, $violations);
@@ -46,7 +64,8 @@ class RiddenCoasterValidationTest extends TestCase
         $violations = $this->validator->validatePropertyValue(
             RiddenCoaster::class,
             'review',
-            'This coaster is absolutely amazing, best drop ever'
+            'This coaster is absolutely amazing, best drop ever',
+            ['review_text']
         );
 
         $this->assertCount(0, $violations);
@@ -57,8 +76,50 @@ class RiddenCoasterValidationTest extends TestCase
         $violations = $this->validator->validatePropertyValue(
             RiddenCoaster::class,
             'review',
-            null
+            null,
+            ['review_text']
         );
+
+        $this->assertCount(0, $violations);
+    }
+
+    /**
+     * Regression test for the whole-branch review finding: the constraint
+     * must be scoped to the "review_text" group, not the implicit
+     * "Default" group, otherwise validating a RiddenCoaster under Default
+     * (e.g. RatingCoasterController's AJAX rating/date-only path, or
+     * EasyAdmin's save) fails for any row whose review already contains a
+     * blocked word — even when review itself isn't being changed.
+     */
+    public function testReviewPropertyIsNotValidatedUnderDefaultGroup(): void
+    {
+        $violations = $this->validator->validatePropertyValue(
+            RiddenCoaster::class,
+            'review',
+            'This coaster is fucking amazing'
+        );
+
+        $this->assertCount(0, $violations);
+    }
+
+    /**
+     * Mirrors RatingCoasterController::editAction(), which calls
+     * $validator->validate($rating) (implicit Default group) on the AJAX
+     * rating/ride-date path that never touches "review". Before the group
+     * fix, a RiddenCoaster whose review already contained a blocked word
+     * (e.g. one of the ~157 pre-existing rows called out in the design
+     * spec) would fail this validate() call even though only value/riddenAt
+     * changed, silently blocking legitimate rating edits.
+     */
+    public function testWholeEntityValidationUnderDefaultGroupIgnoresBlockedReview(): void
+    {
+        $rating = new RiddenCoaster();
+        $rating->setCoaster(new Coaster());
+        $rating->setUser(new User());
+        $rating->setValue(4.5);
+        $rating->setReview('This coaster is fucking amazing');
+
+        $violations = $this->validator->validate($rating);
 
         $this->assertCount(0, $violations);
     }

--- a/tests/Entity/RiddenCoasterValidationTest.php
+++ b/tests/Entity/RiddenCoasterValidationTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\RiddenCoaster;
+use App\Validator\Constraints\NoBlockedWordsValidator;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Validator\ContainerConstraintValidatorFactory;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class RiddenCoasterValidationTest extends TestCase
+{
+    private ValidatorInterface $validator;
+
+    protected function setUp(): void
+    {
+        $validatorLocator = new ServiceLocator([
+            NoBlockedWordsValidator::class => static fn (): NoBlockedWordsValidator => new NoBlockedWordsValidator(new NullLogger()),
+        ]);
+
+        $this->validator = Validation::createValidatorBuilder()
+            ->enableAttributeMapping()
+            ->setConstraintValidatorFactory(new ContainerConstraintValidatorFactory($validatorLocator))
+            ->getValidator();
+    }
+
+    public function testReviewPropertyRejectsBlockedWord(): void
+    {
+        $violations = $this->validator->validatePropertyValue(
+            RiddenCoaster::class,
+            'review',
+            'This coaster is fucking amazing'
+        );
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('blocked_words.review', $violations->get(0)->getMessageTemplate());
+    }
+
+    public function testReviewPropertyAcceptsCleanText(): void
+    {
+        $violations = $this->validator->validatePropertyValue(
+            RiddenCoaster::class,
+            'review',
+            'This coaster is absolutely amazing, best drop ever'
+        );
+
+        $this->assertCount(0, $violations);
+    }
+
+    public function testReviewPropertyAcceptsNull(): void
+    {
+        $violations = $this->validator->validatePropertyValue(
+            RiddenCoaster::class,
+            'review',
+            null
+        );
+
+        $this->assertCount(0, $violations);
+    }
+}

--- a/tests/Form/Type/ReviewTypeTest.php
+++ b/tests/Form/Type/ReviewTypeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Form\Type;
+
+use App\Entity\RiddenCoaster;
+use App\Form\Type\ReviewType;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class ReviewTypeTest extends TestCase
+{
+    /**
+     * Regression test for the whole-branch review finding: the review
+     * submission form (the entry point where NoBlockedWords is actually
+     * meant to be enforced) must validate the "review_text" group in
+     * addition to "Default", otherwise scoping the constraint to a
+     * dedicated group (to unbreak RatingCoasterController/EasyAdmin) would
+     * have silently stopped the form itself from rejecting blocked words.
+     */
+    public function testConfigureOptionsEnablesReviewTextValidationGroup(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $reviewType = new ReviewType($translator);
+
+        $resolver = new OptionsResolver();
+        $reviewType->configureOptions($resolver);
+        $options = $resolver->resolve([]);
+
+        $this->assertSame(RiddenCoaster::class, $options['data_class']);
+        $this->assertSame(['Default', 'review_text'], $options['validation_groups']);
+    }
+}

--- a/tests/Validator/Constraints/BlockedWordListTest.php
+++ b/tests/Validator/Constraints/BlockedWordListTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Validator\Constraints;
+
+use App\Validator\Constraints\BlockedWordList;
+use PHPUnit\Framework\TestCase;
+
+class BlockedWordListTest extends TestCase
+{
+    /** @return iterable<string, array{0: string}> */
+    public static function blockedTextProvider(): iterable
+    {
+        yield 'fuck' => ['This ride is fuck ugly'];
+        yield 'fucking as intensifier (still blocked, deliberate)' => ['This coaster is fucking amazing'];
+        yield 'fucker' => ['What a fucker of a restraint'];
+        yield 'fucked' => ['My back got fucked up'];
+        yield 'putain positive tone (still blocked, deliberate)' => ['Putain que ce coaster est genial'];
+        yield 'goddamn' => ['This is a goddamn good ride'];
+        yield 'goddamned' => ['The goddamned queue was endless'];
+        yield 'bitch' => ['Stop being a bitch about the wait time'];
+        yield 'bitches' => ['These operators are bitches'];
+        yield 'connard' => ["tu es qu'un connard elias"];
+        yield 'connarde' => ['quelle connarde'];
+        yield 'connards' => ['bande de connards'];
+        yield 'asshole' => ['The designer is an asshole'];
+        yield 'assholes' => ['They are all assholes'];
+        yield 'salope' => ['Sale salope'];
+        yield 'uppercase FUCK' => ['FUCK this ride is bad'];
+        yield 'mixed case PuTaIn' => ['PuTaIn ce virage'];
+    }
+
+    /** @dataProvider blockedTextProvider */
+    public function testMatchesReturnsTrueForBlockedWords(string $text): void
+    {
+        $this->assertTrue(BlockedWordList::matches($text));
+    }
+
+    /** @return iterable<string, array{0: string}> */
+    public static function allowedTextProvider(): iterable
+    {
+        yield 'shit' => ['This ride is shit'];
+        yield 'damn' => ['Damn that drop is intense'];
+        yield 'hell' => ['What the hell was that'];
+        yield 'ass' => ['My ass hurts after this ride'];
+        yield 'crap' => ['This queue is crap'];
+        yield 'merde' => ["c'est de la merde"];
+        yield 'merdique' => ['un coaster merdique'];
+        yield 'bordel' => ['quel bordel cette file'];
+        yield 'clean english review' => ['This coaster is absolutely amazing, best drop ever'];
+        yield 'clean french review' => ['Ce coaster est vraiment incroyable, la meilleure chute'];
+        yield 'empty string' => [''];
+    }
+
+    /** @dataProvider allowedTextProvider */
+    public function testMatchesReturnsFalseForAllowedWords(string $text): void
+    {
+        $this->assertFalse(BlockedWordList::matches($text));
+    }
+
+    /** @return iterable<string, array{0: string}> */
+    public static function falsePositiveTrapProvider(): iterable
+    {
+        yield 'french "en retard" (late), not the ableist slur' => ['La théma est en retard sur tout le reste du parc'];
+        yield 'spanish "con" (with), substring of connard-style words' => ['Atracción vertiginosa, con un lanzamiento potente'];
+        yield 'english "con" as in pros and cons' => ['The biggest con of this coaster is the rattle'];
+        yield 'french "salopette" (dungarees), starts with salope' => ["j'ai mis ma salopette pour la piscine"];
+    }
+
+    /** @dataProvider falsePositiveTrapProvider */
+    public function testMatchesReturnsFalseForKnownFalsePositiveTraps(string $text): void
+    {
+        $this->assertFalse(BlockedWordList::matches($text));
+    }
+}

--- a/tests/Validator/Constraints/BlockedWordListTest.php
+++ b/tests/Validator/Constraints/BlockedWordListTest.php
@@ -73,4 +73,20 @@ class BlockedWordListTest extends TestCase
     {
         $this->assertFalse(BlockedWordList::matches($text));
     }
+
+    /**
+     * Regression test for the whole-branch review finding: preg_match()
+     * with the /u modifier returns false (not 0) on malformed UTF-8, and
+     * `1 === preg_match(...)` treats false the same as "no match" — a
+     * silent bypass. Malformed UTF-8 must fail closed (be treated as
+     * blocked) instead.
+     */
+    public function testMatchesReturnsTrueForMalformedUtf8(): void
+    {
+        // Lone continuation byte (0x80): invalid as a standalone UTF-8
+        // sequence, guaranteed to make preg_match() return false under /u.
+        $malformed = "This ride is great \x80\xFF";
+
+        $this->assertTrue(BlockedWordList::matches($malformed));
+    }
 }

--- a/tests/Validator/Constraints/NoBlockedWordsValidatorTest.php
+++ b/tests/Validator/Constraints/NoBlockedWordsValidatorTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Validator\Constraints;
+
+use App\Validator\Constraints\NoBlockedWords;
+use App\Validator\Constraints\NoBlockedWordsValidator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class NoBlockedWordsValidatorTest extends TestCase
+{
+    private NoBlockedWordsValidator $validator;
+    private ExecutionContextInterface&MockObject $context;
+    private ConstraintViolationBuilderInterface&MockObject $violationBuilder;
+    private LoggerInterface&MockObject $logger;
+
+    protected function setUp(): void
+    {
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->validator = new NoBlockedWordsValidator($this->logger);
+        $this->context = $this->createMock(ExecutionContextInterface::class);
+        $this->violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+
+        $this->validator->initialize($this->context);
+    }
+
+    public function testValidateBuildsViolationForBlockedWord(): void
+    {
+        $constraint = new NoBlockedWords();
+
+        $this->violationBuilder->expects($this->once())
+            ->method('addViolation');
+
+        $this->context->expects($this->once())
+            ->method('buildViolation')
+            ->with($constraint->message)
+            ->willReturn($this->violationBuilder);
+
+        $this->validator->validate('This coaster is fucking amazing', $constraint);
+    }
+
+    public function testValidateLogsBlockedSubmission(): void
+    {
+        $constraint = new NoBlockedWords();
+
+        $this->context->method('buildViolation')->willReturn($this->violationBuilder);
+
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with('Review submission blocked: contains a blocked word', $this->anything());
+
+        $this->validator->validate('This coaster is fucking amazing', $constraint);
+    }
+
+    public function testValidatePassesForCleanText(): void
+    {
+        $constraint = new NoBlockedWords();
+
+        $this->context->expects($this->never())
+            ->method('buildViolation');
+
+        $this->logger->expects($this->never())
+            ->method('info');
+
+        $this->validator->validate('This coaster is absolutely amazing', $constraint);
+    }
+
+    public function testValidatePassesForNull(): void
+    {
+        $constraint = new NoBlockedWords();
+
+        $this->context->expects($this->never())
+            ->method('buildViolation');
+
+        $this->validator->validate(null, $constraint);
+    }
+
+    public function testValidatePassesForEmptyString(): void
+    {
+        $constraint = new NoBlockedWords();
+
+        $this->context->expects($this->never())
+            ->method('buildViolation');
+
+        $this->validator->validate('', $constraint);
+    }
+
+    public function testValidateThrowsForWrongConstraintType(): void
+    {
+        $wrongConstraint = $this->createMock(Constraint::class);
+
+        $this->expectException(UnexpectedTypeException::class);
+
+        $this->validator->validate('some text', $wrongConstraint);
+    }
+
+    public function testValidateThrowsForNonStringValue(): void
+    {
+        $constraint = new NoBlockedWords();
+
+        $this->expectException(UnexpectedTypeException::class);
+
+        $this->validator->validate(42, $constraint);
+    }
+}

--- a/translations/validators+intl-icu.de.yml
+++ b/translations/validators+intl-icu.de.yml
@@ -1,4 +1,8 @@
 top_coaster.duplicate: '{coaster} erscheint mehrmals. Entferne bitte die Duplikate.'
+
+# Blocked words in reviews
+blocked_words:
+    review: 'Deine Bewertung enthält nicht erlaubte Ausdrücke. Bitte formuliere sie um.'
 # Ride date validation
 ride_date:
     before_opening: Das Fahrdatum kann nicht vor der Eröffnung der Achterbahn liegen.

--- a/translations/validators+intl-icu.en.yml
+++ b/translations/validators+intl-icu.en.yml
@@ -3,6 +3,10 @@ top_coaster.duplicate: '{coaster} appears several times. Please remove duplicate
 # Admin validators
 date_minimum:
     error: Year must be at least 1800.
+
+# Blocked words in reviews
+blocked_words:
+    review: 'Your review contains language that is not allowed here. Please rephrase and try again.'
 # Ride date validation
 ride_date:
     before_opening: The ride date cannot be before the coaster opened.

--- a/translations/validators+intl-icu.es.yml
+++ b/translations/validators+intl-icu.es.yml
@@ -1,4 +1,8 @@
 top_coaster.duplicate: '{coaster} aparece varias veces. Por favor, borráis los duplicados.'
+
+# Blocked words in reviews
+blocked_words:
+    review: 'Su reseña contiene términos que no están permitidos. Por favor, reformule su reseña.'
 # Ride date validation
 ride_date:
     before_opening: La fecha del viaje no puede ser anterior a la apertura de la montaña rusa.

--- a/translations/validators+intl-icu.fr.yml
+++ b/translations/validators+intl-icu.fr.yml
@@ -1,4 +1,8 @@
 top_coaster.duplicate: '{coaster} est présent plusieurs fois. Merci de supprimer les doublons.'
+
+# Blocked words in reviews
+blocked_words:
+    review: "Votre avis contient des termes qui ne sont pas autorisés. Merci de reformuler."
 # Ride date validation
 ride_date:
     before_opening: La date de passage ne peut pas être antérieure à l'ouverture du coaster.


### PR DESCRIPTION
## Summary
- Rejects review submissions containing a small, frequency-backed list of English/French words with no legitimate non-insulting use (identity-adjacent insults + a few profanity words chosen to be blocked regardless of tone), enforced via a new `NoBlockedWords` validation constraint scoped to the review-submission form only.
- First step of a larger moderation effort; a wordlist alone was validated against real review data before being scoped this narrowly — most moderation load comes from spam/troll content, which is tracked separately for an upcoming LLM-based pass.
- Existing reviews and other entry points (rating-only AJAX updates, admin editing) are intentionally left unaffected — the constraint only fires on the public review form's `review_text` validation group.

## Test plan
- [x] `vendor/bin/phpunit` — 106 tests green
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/php-cs-fixer` — clean
- [x] Manual verification of the fixed-round findings (form now shows the rejection message; AJAX rating path and admin editing no longer break on legacy rows containing a blocked word)

🤖 Generated with [Claude Code](https://claude.com/claude-code)