### PR TITLE
security: restrict Claude workflows to trusted collaborators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             - uses: actions/checkout@v7
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,9 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Only auto-review PRs opened by trusted collaborators (owner/member/outside
+    # collaborator with repo access), even when opened from a fork.
+    if: contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,9 +12,15 @@ on:
 
 jobs:
   claude-review:
-    # Only auto-review PRs opened by trusted collaborators (owner/member/outside
-    # collaborator with repo access), even when opened from a fork.
-    if: contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    # Only auto-review PRs opened by trusted collaborators, and only when the PR
+    # is not from a fork: GitHub withholds OIDC/secrets from fork-triggered
+    # pull_request runs, so a fork PR would otherwise start this job and fail on
+    # the OIDC token fetch, showing as a failed check instead of being skipped.
+    # Trusted collaborators can still get a review on a fork PR by commenting
+    # @claude, which isn't subject to this restriction (see claude.yml).
+    if: |
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
+      github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   claude:
+    # Only trusted collaborators (owner/member/outside collaborator with repo access)
+    # may trigger Claude via @claude mentions.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Gate `claude.yml` (@claude mentions) and `claude-code-review.yml` (auto PR review) on `author_association` (OWNER/MEMBER/COLLABORATOR), so only trusted collaborators can trigger them instead of any GitHub account.
- Pin `ci.yml`'s `GITHUB_TOKEN` to `contents: read`, since it had no explicit `permissions` block and was inheriting the repo's read/write default even on fork PRs.
- Skip `claude-code-review.yml` cleanly (as "skipped", not "failed") when a PR comes from a fork, since GitHub withholds OIDC/secrets from fork-triggered `pull_request` runs regardless of author trust. Trusted collaborators can still get a review on a fork PR by commenting `@claude`, which isn't subject to this restriction.

## Test plan
- [ ] Confirm `@claude` mentions from florian987/richardcrete/shARPII still work on issues/PRs
- [ ] Confirm a stranger commenting `@claude` on a public issue/PR is ignored
- [ ] Confirm `claude-code-review.yml` still auto-runs on non-fork PRs from trusted collaborators
- [ ] Confirm `claude-code-review.yml` shows as skipped (not failed) on a fork PR, e.g. richardcrete's PR #300 after it's updated