### PR TITLE
ci: enforce Conventional Commits format on PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,29 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            revert


### PR DESCRIPTION
## Summary
- Add a title-only check (`amannn/action-semantic-pull-request`) validating that PR titles follow Conventional Commits (`feat:`, `fix:`, `chore:`, ...), since the repo merges via squash and the PR title becomes the commit on `main`.
- Runs on `pull_request_target` but only reads `github.event.pull_request.title` — no checkout, no secrets — so it's safe to run on every PR including forks, and works for all contributors without any local tooling.

## Follow-up (manual, outside this PR)
Once merged, add the `lint-title` check to the required status checks on `main` (Settings → Branches → main → Require status checks to pass), same as `build`, so non-conforming titles actually block merging.

## Test plan
- [ ] Open a PR with a bad title (e.g. `Update stuff`) and confirm the check fails
- [ ] Rename it to a conforming title (e.g. `fix: update stuff`) and confirm the check passes
- [ ] Confirm it runs on a fork PR too