### PR TITLE
fix: make Claude Code Review actually post its findings

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -42,7 +42,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- `claude-code-review.yml` has been running on every eligible PR but never posting anything visible: the prompt was missing `--comment`, so findings only went to the workflow log — and that log is hidden by default (`Running Claude Code via SDK (full output hidden for security)`), so the review's cost was paying for output nobody could see.
- Add `--comment` to the prompt so Claude posts inline comments / a summary on the PR.
- Grant the `mcp__github_inline_comment__create_inline_comment` MCP tool via `claude_args`/`--allowedTools`, matching Anthropic's own documented example — without it the action has no way to post inline comments even with `--comment`.
- Bump `pull-requests` from `read` to `write`, required to actually post a comment.

## Test plan
- [ ] Open a small test PR (or push a commit to an existing open one) and confirm a Claude review comment/inline comments actually appear on the PR this time