### PR TITLE
fix: cache configuration bugs and cleanup

### DIFF
--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -16,10 +16,10 @@ framework:
         # Namespaced pools use the above "app" backend by default
         pools:
             # Search-related caching (Redis for fast access)
-            search.cache:
+            search.cache_pool:
                 adapter: cache.adapter.redis
 
             # Sitemap cache (Redis for persistent data across deployments)
-            sitemap.cache:
+            sitemap.cache_pool:
                 adapter: cache.adapter.redis
                 default_lifetime: 604800 # 7 days

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -65,7 +65,7 @@ when@prod:
                 pool: doctrine.result_cache_pool
             metadata_cache_driver:
                 type: pool
-                pool: doctrine.metadata_cache_pool
+                pool: doctrine.system_cache_pool
 
     framework:
         cache:
@@ -74,5 +74,3 @@ when@prod:
                     adapter: cache.adapter.redis
                 doctrine.system_cache_pool:
                     adapter: cache.system
-                doctrine.metadata_cache_pool:
-                    adapter: cache.adapter.filesystem

--- a/src/Command/SitemapUpdateCommand.php
+++ b/src/Command/SitemapUpdateCommand.php
@@ -23,7 +23,7 @@ class SitemapUpdateCommand extends Command
 {
     public function __construct(
         private readonly SitemapService $sitemapService,
-        #[Autowire(service: 'sitemap.cache')]
+        #[Autowire(service: 'sitemap.cache_pool')]
         private readonly CacheInterface $sitemapCache
     ) {
         parent::__construct();

--- a/src/Controller/SitemapController.php
+++ b/src/Controller/SitemapController.php
@@ -13,7 +13,7 @@ use Symfony\Contracts\Cache\CacheInterface;
 class SitemapController extends AbstractController
 {
     public function __construct(
-        #[Autowire(service: 'sitemap.cache')]
+        #[Autowire(service: 'sitemap.cache_pool')]
         private readonly CacheInterface $sitemapCache
     ) {
     }

--- a/src/DTO/SearchResponseDTO.php
+++ b/src/DTO/SearchResponseDTO.php
@@ -6,9 +6,6 @@ namespace App\DTO;
 
 class SearchResponseDTO
 {
-    /** @var array<string, mixed> */
-    public array $debug = [];
-
     /**
      * @param array<string, array<SearchResultDTO>> $results
      * @param array<string, int>                    $totalResults
@@ -32,18 +29,11 @@ class SearchResponseDTO
             );
         }
 
-        $response = [
+        return [
             'query' => $this->query,
             'results' => $formattedResults,
             'totalResults' => $this->totalResults,
             'hasMore' => $this->hasMore,
         ];
-
-        // Add debug info if available
-        if (!empty($this->debug)) {
-            $response['debug'] = $this->debug;
-        }
-
-        return $response;
     }
 }

--- a/src/EventListener/CoasterListener.php
+++ b/src/EventListener/CoasterListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\EventListener;
 
 use App\Entity\Coaster;
+use App\Service\FilterService;
 use App\Service\SearchCacheService;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
 use Doctrine\ORM\Events;
@@ -12,15 +13,24 @@ use Doctrine\ORM\Events;
 #[AsEntityListener(event: Events::postPersist, method: 'invalidateSearchCache', entity: Coaster::class)]
 #[AsEntityListener(event: Events::postUpdate, method: 'invalidateSearchCache', entity: Coaster::class)]
 #[AsEntityListener(event: Events::postRemove, method: 'invalidateSearchCache', entity: Coaster::class)]
+#[AsEntityListener(event: Events::postPersist, method: 'invalidateFilterCache', entity: Coaster::class)]
+#[AsEntityListener(event: Events::postUpdate, method: 'invalidateFilterCache', entity: Coaster::class)]
+#[AsEntityListener(event: Events::postRemove, method: 'invalidateFilterCache', entity: Coaster::class)]
 class CoasterListener
 {
     public function __construct(
-        private readonly SearchCacheService $searchCacheService
+        private readonly SearchCacheService $searchCacheService,
+        private readonly FilterService $filterService
     ) {
     }
 
     public function invalidateSearchCache(): void
     {
         $this->searchCacheService->invalidateSearchCache();
+    }
+
+    public function invalidateFilterCache(): void
+    {
+        $this->filterService->clearFilterCache();
     }
 }

--- a/src/EventListener/FilterVocabularyListener.php
+++ b/src/EventListener/FilterVocabularyListener.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+use App\Entity\Continent;
+use App\Entity\Country;
+use App\Entity\Manufacturer;
+use App\Entity\MaterialType;
+use App\Entity\Model;
+use App\Entity\SeatingType;
+use App\Service\FilterService;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
+use Doctrine\ORM\Events;
+
+#[AsEntityListener(event: Events::postPersist, method: 'invalidateFilterCache', entity: Continent::class)]
+#[AsEntityListener(event: Events::postUpdate, method: 'invalidateFilterCache', entity: Continent::class)]
+#[AsEntityListener(event: Events::postRemove, method: 'invalidateFilterCache', entity: Continent::class)]
+#[AsEntityListener(event: Events::postPersist, method: 'invalidateFilterCache', entity: Country::class)]
+#[AsEntityListener(event: Events::postUpdate, method: 'invalidateFilterCache', entity: Country::class)]
+#[AsEntityListener(event: Events::postRemove, method: 'invalidateFilterCache', entity: Country::class)]
+#[AsEntityListener(event: Events::postPersist, method: 'invalidateFilterCache', entity: Manufacturer::class)]
+#[AsEntityListener(event: Events::postUpdate, method: 'invalidateFilterCache', entity: Manufacturer::class)]
+#[AsEntityListener(event: Events::postRemove, method: 'invalidateFilterCache', entity: Manufacturer::class)]
+#[AsEntityListener(event: Events::postPersist, method: 'invalidateFilterCache', entity: MaterialType::class)]
+#[AsEntityListener(event: Events::postUpdate, method: 'invalidateFilterCache', entity: MaterialType::class)]
+#[AsEntityListener(event: Events::postRemove, method: 'invalidateFilterCache', entity: MaterialType::class)]
+#[AsEntityListener(event: Events::postPersist, method: 'invalidateFilterCache', entity: Model::class)]
+#[AsEntityListener(event: Events::postUpdate, method: 'invalidateFilterCache', entity: Model::class)]
+#[AsEntityListener(event: Events::postRemove, method: 'invalidateFilterCache', entity: Model::class)]
+#[AsEntityListener(event: Events::postPersist, method: 'invalidateFilterCache', entity: SeatingType::class)]
+#[AsEntityListener(event: Events::postUpdate, method: 'invalidateFilterCache', entity: SeatingType::class)]
+#[AsEntityListener(event: Events::postRemove, method: 'invalidateFilterCache', entity: SeatingType::class)]
+class FilterVocabularyListener
+{
+    public function __construct(
+        private readonly FilterService $filterService
+    ) {
+    }
+
+    public function invalidateFilterCache(): void
+    {
+        $this->filterService->clearFilterCache();
+    }
+}

--- a/src/Service/SearchCacheService.php
+++ b/src/Service/SearchCacheService.php
@@ -56,33 +56,6 @@ class SearchCacheService
         $this->cache->clear();
     }
 
-    public function invalidateAutocompleteCache(): void
-    {
-        try {
-            $this->cache->deleteItem('main_autocomplete');
-        } catch (\Exception) {
-            // If cache fails, silently continue
-        }
-    }
-
-    public function invalidateCoasterCache(): void
-    {
-        try {
-            $this->cache->deleteItem('coaster_search_all');
-        } catch (\Exception) {
-            // If cache fails, silently continue
-        }
-    }
-
-    public function invalidateParkCache(): void
-    {
-        try {
-            $this->cache->deleteItem('park_search_all');
-        } catch (\Exception) {
-            // If cache fails, silently continue
-        }
-    }
-
     /** @param array<string> $popularQueries */
     public function warmCache(array $popularQueries): void
     {
@@ -104,7 +77,6 @@ class SearchCacheService
 
     private function getCacheKey(string $query): string
     {
-        // Replace colon with underscore to avoid reserved character issues
-        return str_replace(':', '_', self::CACHE_PREFIX).md5(strtolower(trim($query)));
+        return self::CACHE_PREFIX.md5(strtolower(trim($query)));
     }
 }

--- a/src/Service/SearchCacheService.php
+++ b/src/Service/SearchCacheService.php
@@ -56,25 +56,6 @@ class SearchCacheService
         $this->cache->clear();
     }
 
-    /** @param array<string> $popularQueries */
-    public function warmCache(array $popularQueries): void
-    {
-        foreach ($popularQueries as $query) {
-            $cacheKey = $this->getCacheKey($query);
-            try {
-                // Pre-warm cache with empty placeholder that will be filled by actual search
-                $item = $this->cache->getItem($cacheKey);
-                if (!$item->isHit()) {
-                    $item->set([]);
-                    $item->expiresAfter(self::CACHE_TTL);
-                    $this->cache->save($item);
-                }
-            } catch (\Exception) {
-                // If cache fails, silently continue
-            }
-        }
-    }
-
     private function getCacheKey(string $query): string
     {
         return self::CACHE_PREFIX.md5(strtolower(trim($query)));

--- a/src/Service/SearchCacheService.php
+++ b/src/Service/SearchCacheService.php
@@ -9,55 +9,14 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 class SearchCacheService
 {
-    private const int CACHE_TTL = 900; // 15 minutes
-    private const string CACHE_PREFIX = 'search_';
-
     public function __construct(
         #[Autowire(service: 'search.cache_pool')]
         private readonly CacheItemPoolInterface $cache
     ) {
     }
 
-    /** @return array<string, mixed>|null */
-    public function getCachedResults(string $query, int $limit): ?array
-    {
-        $cacheKey = $this->getCacheKey($query, $limit);
-
-        try {
-            $item = $this->cache->getItem($cacheKey);
-            if ($item->isHit()) {
-                return $item->get();
-            }
-
-            return null;
-        } catch (\Exception) {
-            // If cache fails, return null to indicate cache miss
-            return null;
-        }
-    }
-
-    /** @param array<string, mixed> $results */
-    public function setCachedResults(string $query, int $limit, array $results): void
-    {
-        $cacheKey = $this->getCacheKey($query, $limit);
-
-        try {
-            $item = $this->cache->getItem($cacheKey);
-            $item->set($results);
-            $item->expiresAfter(self::CACHE_TTL);
-            $this->cache->save($item);
-        } catch (\Exception) {
-            // If cache fails, silently continue without caching
-        }
-    }
-
     public function invalidateSearchCache(): void
     {
         $this->cache->clear();
-    }
-
-    private function getCacheKey(string $query, int $limit): string
-    {
-        return self::CACHE_PREFIX.$limit.'_'.md5(strtolower(trim($query)));
     }
 }

--- a/src/Service/SearchCacheService.php
+++ b/src/Service/SearchCacheService.php
@@ -13,7 +13,7 @@ class SearchCacheService
     private const string CACHE_PREFIX = 'search_';
 
     public function __construct(
-        #[Autowire(service: 'search.cache')]
+        #[Autowire(service: 'search.cache_pool')]
         private readonly CacheItemPoolInterface $cache
     ) {
     }

--- a/src/Service/SearchCacheService.php
+++ b/src/Service/SearchCacheService.php
@@ -19,9 +19,9 @@ class SearchCacheService
     }
 
     /** @return array<string, mixed>|null */
-    public function getCachedResults(string $query): ?array
+    public function getCachedResults(string $query, int $limit): ?array
     {
-        $cacheKey = $this->getCacheKey($query);
+        $cacheKey = $this->getCacheKey($query, $limit);
 
         try {
             $item = $this->cache->getItem($cacheKey);
@@ -37,9 +37,9 @@ class SearchCacheService
     }
 
     /** @param array<string, mixed> $results */
-    public function setCachedResults(string $query, array $results): void
+    public function setCachedResults(string $query, int $limit, array $results): void
     {
-        $cacheKey = $this->getCacheKey($query);
+        $cacheKey = $this->getCacheKey($query, $limit);
 
         try {
             $item = $this->cache->getItem($cacheKey);
@@ -56,8 +56,8 @@ class SearchCacheService
         $this->cache->clear();
     }
 
-    private function getCacheKey(string $query): string
+    private function getCacheKey(string $query, int $limit): string
     {
-        return self::CACHE_PREFIX.md5(strtolower(trim($query)));
+        return self::CACHE_PREFIX.$limit.'_'.md5(strtolower(trim($query)));
     }
 }

--- a/src/Service/SearchService.php
+++ b/src/Service/SearchService.php
@@ -39,7 +39,7 @@ class SearchService
     /** SearchService constructor. */
     public function __construct(
         private readonly EntityManagerInterface $em,
-        #[Autowire(service: 'search.cache')]
+        #[Autowire(service: 'search.cache_pool')]
         private readonly CacheInterface $cache
     ) {
     }

--- a/src/Service/SearchService.php
+++ b/src/Service/SearchService.php
@@ -13,9 +13,14 @@ use App\Repository\CoasterRepository;
 use App\Repository\ParkRepository;
 use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 
 class SearchService
 {
+    private const int CACHE_TTL = 900; // 15 minutes
+
     final public const array COASTER = [
         'emoji' => '🎢',
         'route' => 'redirect_coaster_show',
@@ -34,59 +39,56 @@ class SearchService
     /** SearchService constructor. */
     public function __construct(
         private readonly EntityManagerInterface $em,
-        private readonly SearchCacheService $cacheService
+        #[Autowire(service: 'search.cache')]
+        private readonly CacheInterface $cache
     ) {
     }
 
     /** Search across all entity types with caching support. */
     public function searchAll(string $query, int $limit = 5): SearchResponseDTO
     {
-        try {
-            $cachedResults = $this->cacheService->getCachedResults($query, $limit);
+        $cacheKey = 'search_all_'.$limit.'_'.md5(strtolower(trim($query)));
 
-            if (null !== $cachedResults) {
-                return new SearchResponseDTO(
-                    $query,
-                    $cachedResults['results'],
-                    $cachedResults['totalResults'],
-                    $cachedResults['hasMore']
-                );
-            }
+        try {
+            $data = $this->cache->get($cacheKey, function (ItemInterface $item) use ($query, $limit) {
+                $item->expiresAfter(self::CACHE_TTL);
+
+                return $this->computeSearchData($query, $limit);
+            });
         } catch (\Exception) {
-            // If caching fails, continue without cache
+            // If caching fails, search without it
+            $data = $this->computeSearchData($query, $limit);
         }
 
+        return new SearchResponseDTO($query, $data['results'], $data['totalResults'], $data['hasMore']);
+    }
+
+    /**
+     * @return array{
+     *     results: array<string, array<int, SearchResultDTO>>,
+     *     totalResults: array<string, int>,
+     *     hasMore: bool
+     * }
+     */
+    private function computeSearchData(string $query, int $limit): array
+    {
         $coasters = $this->searchCoasters($query, $limit);
         $parks = $this->searchParks($query, $limit);
         $users = $this->searchUsers($query, $limit);
 
-        $results = [
-            'coasters' => $coasters,
-            'parks' => $parks,
-            'users' => $users,
+        return [
+            'results' => [
+                'coasters' => $coasters,
+                'parks' => $parks,
+                'users' => $users,
+            ],
+            'totalResults' => [
+                'coasters' => \count($coasters),
+                'parks' => \count($parks),
+                'users' => \count($users),
+            ],
+            'hasMore' => \count($coasters) >= $limit || \count($parks) >= $limit || \count($users) >= $limit,
         ];
-
-        $totalResults = [
-            'coasters' => \count($coasters),
-            'parks' => \count($parks),
-            'users' => \count($users),
-        ];
-
-        $hasMore = \count($coasters) >= $limit || \count($parks) >= $limit || \count($users) >= $limit;
-
-        $response = new SearchResponseDTO($query, $results, $totalResults, $hasMore);
-
-        try {
-            $this->cacheService->setCachedResults($query, $limit, [
-                'results' => $results,
-                'totalResults' => $totalResults,
-                'hasMore' => $hasMore,
-            ]);
-        } catch (\Exception) {
-            // If caching fails, continue without cache
-        }
-
-        return $response;
     }
 
     /**

--- a/src/Service/SearchService.php
+++ b/src/Service/SearchService.php
@@ -41,35 +41,23 @@ class SearchService
     /** Search across all entity types with caching support. */
     public function searchAll(string $query, int $limit = 5): SearchResponseDTO
     {
-        $fromCache = false;
-        $cacheKey = $this->getCacheKey($query);
+        $cacheKey = $this->getCacheKey($query, $limit);
 
         try {
             $cachedResults = $this->cacheService->getCachedResults($cacheKey);
 
             if (null !== $cachedResults) {
-                $fromCache = true;
-                error_log("🔥 REDIS CACHE HIT for query: '{$query}'");
-
-                $response = new SearchResponseDTO(
+                return new SearchResponseDTO(
                     $query,
                     $cachedResults['results'],
                     $cachedResults['totalResults'],
                     $cachedResults['hasMore']
                 );
-
-                // Add debug info to response
-                $response->debug = ['source' => 'redis_cache', 'cache_key' => $cacheKey];
-
-                return $response;
             }
-            error_log("💾 REDIS CACHE MISS for query: '{$query}'");
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // If caching fails, continue without cache
-            error_log('Search cache error: '.$e->getMessage());
         }
 
-        error_log("🔍 DATABASE QUERY for query: '{$query}'");
         $coasters = $this->searchCoasters($query, $limit);
         $parks = $this->searchParks($query, $limit);
         $users = $this->searchUsers($query, $limit);
@@ -90,20 +78,14 @@ class SearchService
 
         $response = new SearchResponseDTO($query, $results, $totalResults, $hasMore);
 
-        // Add debug info to response
-        $response->debug = ['source' => 'database', 'cached' => false];
-
         try {
-            // Cache the results
             $this->cacheService->setCachedResults($cacheKey, [
                 'results' => $results,
                 'totalResults' => $totalResults,
                 'hasMore' => $hasMore,
             ]);
-            error_log("💾 REDIS CACHE SET for query: '{$query}'");
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // If caching fails, continue without cache
-            error_log('Search cache set error: '.$e->getMessage());
         }
 
         return $response;
@@ -351,8 +333,8 @@ class SearchService
     }
 
     /** Generate cache key for search query. */
-    private function getCacheKey(string $query): string
+    private function getCacheKey(string $query, int $limit): string
     {
-        return 'search_all_'.md5(strtolower(trim($query)));
+        return 'search_all_'.$limit.'_'.md5(strtolower(trim($query)));
     }
 }

--- a/src/Service/SearchService.php
+++ b/src/Service/SearchService.php
@@ -41,10 +41,8 @@ class SearchService
     /** Search across all entity types with caching support. */
     public function searchAll(string $query, int $limit = 5): SearchResponseDTO
     {
-        $cacheKey = $this->getCacheKey($query, $limit);
-
         try {
-            $cachedResults = $this->cacheService->getCachedResults($cacheKey);
+            $cachedResults = $this->cacheService->getCachedResults($query, $limit);
 
             if (null !== $cachedResults) {
                 return new SearchResponseDTO(
@@ -79,7 +77,7 @@ class SearchService
         $response = new SearchResponseDTO($query, $results, $totalResults, $hasMore);
 
         try {
-            $this->cacheService->setCachedResults($cacheKey, [
+            $this->cacheService->setCachedResults($query, $limit, [
                 'results' => $results,
                 'totalResults' => $totalResults,
                 'hasMore' => $hasMore,
@@ -330,11 +328,5 @@ class SearchService
         similar_text($name, $query, $similarity);
 
         return $similarity;
-    }
-
-    /** Generate cache key for search query. */
-    private function getCacheKey(string $query, int $limit): string
-    {
-        return 'search_all_'.$limit.'_'.md5(strtolower(trim($query)));
     }
 }


### PR DESCRIPTION
## Summary
Full cache audit across the app, consolidated into one PR.

- **Doctrine metadata cache never cleared on deploy** — routed through a filesystem pool outside `var/cache/{env}`, so `cache:clear`'s rebuild-and-swap never touched it. Now shares `doctrine.system_cache_pool` with the query cache, same as it does.
- **Filter cache never invalidated** — `FilterService::clearFilterCache()` existed but had no caller. New entries in any of 6 vocabulary entities (manufacturer, model, material/seating type, country, continent) or a new coaster opening year stayed rejected as invalid filters for up to 24h. Added entity listeners mirroring the existing search-cache pattern.
- **Search cache key ignored the `limit` param** — `/search/api?limit=1` and `?limit=5` for the same query shared one Redis entry; whichever hit first served its result count to the other for 15 minutes. Fixed, and refactored `SearchService`/`SearchCacheService` to use `CacheInterface::get()` (matching `FilterService`/`SitemapController`'s existing pattern) instead of hand-rolled get/set split across two classes — removes the duplicate key-building that caused the bug, adds cache-stampede protection for free.
- **Dead code removed**: `SearchCacheService::warmCache()` and 3 unused `invalidate*Cache()` methods (no callers anywhere), leftover debug `error_log()` calls and a `debug` field leaking cache internals into every `/search/api` response.
- **Naming**: `search.cache`/`sitemap.cache` → `search.cache_pool`/`sitemap.cache_pool`, matching `doctrine.*_pool` and Symfony's own terminology.

## Test plan
- [x] `phpunit`, `phpstan`, `php-cs-fixer`, container lint (dev+prod) — all pass
- [x] `doctrine:schema:validate`, prod `cache:clear` — metadata cache confirmed writing into `var/cache/prod/pools/system` (rebuilt on every clear)
- [x] Live-tested against the running dev server/DB: `/search/api?limit=1` then `?limit=5` for the same query return correctly distinct results; saved a Manufacturer via EasyAdmin and confirmed the new filter-cache listener fires with zero errors