### PR TITLE
fix(ai-summary, moderation): accent-stripping, jargon translation, log severity, moderation recalibration

### DIFF
--- a/src/Command/CompareSummaryModelsCommand.php
+++ b/src/Command/CompareSummaryModelsCommand.php
@@ -115,13 +115,20 @@ class CompareSummaryModelsCommand extends Command
             ? \sprintf('%d same-language + %d backfilled = %d total', $reviewCount, $totalReviewCount - $reviewCount, $totalReviewCount)
             : (string) $reviewCount;
 
+        $cacheReadTokens = $metadata['cache_read_tokens'] ?? 0;
+        $cacheWriteTokens = $metadata['cache_write_tokens'] ?? 0;
+        $cacheSuffix = ($cacheReadTokens > 0 || $cacheWriteTokens > 0)
+            ? \sprintf(' (%s cached, %s cache-write)', $cacheReadTokens, $cacheWriteTokens)
+            : '';
+
         $io->writeln(\sprintf(
-            'Model: %s | Reviews analyzed: %s | Latency: %sms | Tokens: %s+%s | Cost: $%s',
+            'Model: %s | Reviews analyzed: %s | Latency: %sms | Tokens: %s+%s%s | Cost: $%s',
             $preview['model_key'] ?? $metadata['model'] ?? 'unknown',
             $reviewsLabel,
             $metadata['latency_ms'] ?? '?',
             $metadata['input_tokens'] ?? '?',
             $metadata['output_tokens'] ?? '?',
+            $cacheSuffix,
             isset($metadata['cost_usd']) ? number_format((float) $metadata['cost_usd'], 4) : '?'
         ));
     }

--- a/src/Command/GenerateCoasterSummariesCommand.php
+++ b/src/Command/GenerateCoasterSummariesCommand.php
@@ -187,12 +187,7 @@ class GenerateCoasterSummariesCommand extends Command
                         $reason = $result['reason'] ?? 'unknown';
 
                         if ('insufficient_reviews' === $reason) {
-                            // Expected, non-actionable: a candidate from the eligibility query
-                            // no longer qualifies by generation time (e.g. review counts
-                            // changed in between). CoasterSummaryService::runAnalysis() already
-                            // logs this at info level - don't log it again here, and don't
-                            // escalate it to error, that's what was paging Discord for routine,
-                            // benign skips.
+                            // Already logged at info level inside CoasterSummaryService.
                         } else {
                             $this->logger->error('Failed to generate summary', [
                                 'coaster_id' => $coaster->getId(),

--- a/src/Command/GenerateCoasterSummariesCommand.php
+++ b/src/Command/GenerateCoasterSummariesCommand.php
@@ -179,7 +179,10 @@ class GenerateCoasterSummariesCommand extends Command
                         $metadata = $result['metadata'];
 
                         $io->writeln("    ✓ Generated: {$summary->getReviewsAnalyzed()} reviews, ".\count($summary->getDynamicPros()).' pros, '.\count($summary->getDynamicCons()).' cons');
-                        $io->writeln("    Performance: {$metadata['latency_ms']}ms, {$metadata['input_tokens']}+{$metadata['output_tokens']} tokens, $".number_format($metadata['cost_usd'], 4));
+                        $cacheSuffix = $metadata['cache_read_tokens'] > 0 || $metadata['cache_write_tokens'] > 0
+                            ? " ({$metadata['cache_read_tokens']} cached, {$metadata['cache_write_tokens']} cache-write)"
+                            : '';
+                        $io->writeln("    Performance: {$metadata['latency_ms']}ms, {$metadata['input_tokens']}+{$metadata['output_tokens']} tokens{$cacheSuffix}, $".number_format($metadata['cost_usd'], 4));
                     } else {
                         $reason = $result['reason'] ?? 'unknown';
 

--- a/src/Command/GenerateCoasterSummariesCommand.php
+++ b/src/Command/GenerateCoasterSummariesCommand.php
@@ -182,14 +182,29 @@ class GenerateCoasterSummariesCommand extends Command
                         $io->writeln("    Performance: {$metadata['latency_ms']}ms, {$metadata['input_tokens']}+{$metadata['output_tokens']} tokens, $".number_format($metadata['cost_usd'], 4));
                     } else {
                         $reason = $result['reason'] ?? 'unknown';
-                        $this->logger->error('Failed to generate summary', [
-                            'coaster_id' => $coaster->getId(),
-                            'coaster_name' => $coaster->getName(),
-                            'language' => $language,
-                            'reason' => $reason,
-                            'review_count' => $result['review_count'] ?? null,
-                            'metadata' => $result['metadata'] ?? null,
-                        ]);
+
+                        if ('insufficient_reviews' === $reason) {
+                            // Expected, non-actionable: a candidate from the eligibility query
+                            // no longer qualifies by generation time (e.g. review counts
+                            // changed in between). Already logged at info level inside
+                            // CoasterSummaryService - don't also escalate it to error here,
+                            // that's what was paging Discord for routine, benign skips.
+                            $this->logger->info('Skipped: insufficient reviews', [
+                                'coaster_id' => $coaster->getId(),
+                                'coaster_name' => $coaster->getName(),
+                                'language' => $language,
+                                'review_count' => $result['review_count'] ?? null,
+                            ]);
+                        } else {
+                            $this->logger->error('Failed to generate summary', [
+                                'coaster_id' => $coaster->getId(),
+                                'coaster_name' => $coaster->getName(),
+                                'language' => $language,
+                                'reason' => $reason,
+                                'review_count' => $result['review_count'] ?? null,
+                                'metadata' => $result['metadata'] ?? null,
+                            ]);
+                        }
 
                         $failureMessage = "    ⚠ {$language} failed ({$reason})";
                         if ('insufficient_reviews' === $reason) {

--- a/src/Command/GenerateCoasterSummariesCommand.php
+++ b/src/Command/GenerateCoasterSummariesCommand.php
@@ -189,15 +189,10 @@ class GenerateCoasterSummariesCommand extends Command
                         if ('insufficient_reviews' === $reason) {
                             // Expected, non-actionable: a candidate from the eligibility query
                             // no longer qualifies by generation time (e.g. review counts
-                            // changed in between). Already logged at info level inside
-                            // CoasterSummaryService - don't also escalate it to error here,
-                            // that's what was paging Discord for routine, benign skips.
-                            $this->logger->info('Skipped: insufficient reviews', [
-                                'coaster_id' => $coaster->getId(),
-                                'coaster_name' => $coaster->getName(),
-                                'language' => $language,
-                                'review_count' => $result['review_count'] ?? null,
-                            ]);
+                            // changed in between). CoasterSummaryService::runAnalysis() already
+                            // logs this at info level - don't log it again here, and don't
+                            // escalate it to error, that's what was paging Discord for routine,
+                            // benign skips.
                         } else {
                             $this->logger->error('Failed to generate summary', [
                                 'coaster_id' => $coaster->getId(),

--- a/src/Service/BedrockService.php
+++ b/src/Service/BedrockService.php
@@ -25,15 +25,27 @@ class BedrockService
             'output_cost_per_1k' => 0.0006,
             'reasoning_effort' => 'low',
         ],
+        // Rates below are the "Global CRIS" row (our modelId uses the global. prefix) from
+        // the model card's own pricing table, not the prompt-caching guide (that page only
+        // documents caching for this model via the Responses API - Converse caches it too,
+        // confirmed live, but AWS doesn't document why; this pricing table isn't scoped to
+        // a specific API, so it's the best available source for what a Converse-triggered
+        // cache read/write actually costs): https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html
         'gpt-5.6-luna' => [
             'id' => 'global.openai.gpt-5.6-luna',
             'input_cost_per_1k' => 0.0002,
             'output_cost_per_1k' => 0.0012,
-            'supports_temperature' => false,
-            // Bedrock caches this model's prompts automatically (see invokeModel()). Per AWS
-            // docs, cache reads are a 90% discount off the input rate, cache writes are 1.25x.
             'cache_read_cost_per_1k' => 0.00002,
             'cache_write_cost_per_1k' => 0.00025,
+            // Prompts whose total input (input + cache read + cache write) tokens exceed this
+            // move from the "Short Context Window (272K)" price row to "Long Context Window
+            // (1M)" - not a flat multiplier: input/cache rates double, output only rises 1.5x.
+            'long_context_threshold_tokens' => 272_000,
+            'long_context_input_cost_per_1k' => 0.0004,
+            'long_context_output_cost_per_1k' => 0.0018,
+            'long_context_cache_read_cost_per_1k' => 0.00004,
+            'long_context_cache_write_cost_per_1k' => 0.0005,
+            'supports_temperature' => false,
         ],
     ];
 
@@ -86,10 +98,18 @@ class BedrockService
 
             $latencyMs = $result['metrics']['latencyMs'] ?? null;
 
-            $inputCost = ($inputTokens / 1000) * $model['input_cost_per_1k'];
-            $outputCost = ($outputTokens / 1000) * $model['output_cost_per_1k'];
-            $cacheReadCost = ($cacheReadTokens / 1000) * ($model['cache_read_cost_per_1k'] ?? $model['input_cost_per_1k']);
-            $cacheWriteCost = ($cacheWriteTokens / 1000) * ($model['cache_write_cost_per_1k'] ?? $model['input_cost_per_1k']);
+            $totalInputTokens = $inputTokens + $cacheReadTokens + $cacheWriteTokens;
+            $isLongContext = isset($model['long_context_threshold_tokens']) && $totalInputTokens > $model['long_context_threshold_tokens'];
+
+            $inputRate = $isLongContext ? $model['long_context_input_cost_per_1k'] : $model['input_cost_per_1k'];
+            $outputRate = $isLongContext ? $model['long_context_output_cost_per_1k'] : $model['output_cost_per_1k'];
+            $cacheReadRate = ($isLongContext ? ($model['long_context_cache_read_cost_per_1k'] ?? null) : ($model['cache_read_cost_per_1k'] ?? null)) ?? $inputRate;
+            $cacheWriteRate = ($isLongContext ? ($model['long_context_cache_write_cost_per_1k'] ?? null) : ($model['cache_write_cost_per_1k'] ?? null)) ?? $inputRate;
+
+            $inputCost = ($inputTokens / 1000) * $inputRate;
+            $outputCost = ($outputTokens / 1000) * $outputRate;
+            $cacheReadCost = ($cacheReadTokens / 1000) * $cacheReadRate;
+            $cacheWriteCost = ($cacheWriteTokens / 1000) * $cacheWriteRate;
             $totalCost = $inputCost + $outputCost + $cacheReadCost + $cacheWriteCost;
 
             $metadata = [

--- a/src/Service/BedrockService.php
+++ b/src/Service/BedrockService.php
@@ -25,13 +25,8 @@ class BedrockService
             'output_cost_per_1k' => 0.0006,
             'reasoning_effort' => 'low',
         ],
-        // Rates below are the "Global CRIS, Short Context Window (272K)" row (our modelId
-        // uses the global. prefix, and prompts here stay well under 272K) from the model
-        // card's own pricing table, not the prompt-caching guide (that page only documents
-        // caching for this model via the Responses API - Converse caches it too, confirmed
-        // live, but AWS doesn't document why; this pricing table isn't scoped to a specific
-        // API, so it's the best available source for what a Converse-triggered cache
-        // read/write actually costs): https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html
+        // Global CRIS, short-context rates from the model card:
+        // https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html
         'gpt-5.6-luna' => [
             'id' => 'global.openai.gpt-5.6-luna',
             'input_cost_per_1k' => 0.0002,
@@ -79,10 +74,7 @@ class BedrockService
             $result = $response->toArray();
             $stopReason = $result['stopReason'] ?? null;
 
-            // latencyMs lives under metrics, not a response header. Bedrock applies prompt
-            // caching automatically for cache-capable models with no cachePoint required, so
-            // cacheReadInputTokens/cacheWriteInputTokens need their own rates below - otherwise
-            // a cache hit reports as if almost no input tokens were used at all.
+            // latencyMs lives under metrics, not a response header.
             $usage = $result['usage'] ?? [];
             $inputTokens = $usage['inputTokens'] ?? 0;
             $outputTokens = $usage['outputTokens'] ?? 0;

--- a/src/Service/BedrockService.php
+++ b/src/Service/BedrockService.php
@@ -25,26 +25,19 @@ class BedrockService
             'output_cost_per_1k' => 0.0006,
             'reasoning_effort' => 'low',
         ],
-        // Rates below are the "Global CRIS" row (our modelId uses the global. prefix) from
-        // the model card's own pricing table, not the prompt-caching guide (that page only
-        // documents caching for this model via the Responses API - Converse caches it too,
-        // confirmed live, but AWS doesn't document why; this pricing table isn't scoped to
-        // a specific API, so it's the best available source for what a Converse-triggered
-        // cache read/write actually costs): https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html
+        // Rates below are the "Global CRIS, Short Context Window (272K)" row (our modelId
+        // uses the global. prefix, and prompts here stay well under 272K) from the model
+        // card's own pricing table, not the prompt-caching guide (that page only documents
+        // caching for this model via the Responses API - Converse caches it too, confirmed
+        // live, but AWS doesn't document why; this pricing table isn't scoped to a specific
+        // API, so it's the best available source for what a Converse-triggered cache
+        // read/write actually costs): https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html
         'gpt-5.6-luna' => [
             'id' => 'global.openai.gpt-5.6-luna',
             'input_cost_per_1k' => 0.0002,
             'output_cost_per_1k' => 0.0012,
             'cache_read_cost_per_1k' => 0.00002,
             'cache_write_cost_per_1k' => 0.00025,
-            // Prompts whose total input (input + cache read + cache write) tokens exceed this
-            // move from the "Short Context Window (272K)" price row to "Long Context Window
-            // (1M)" - not a flat multiplier: input/cache rates double, output only rises 1.5x.
-            'long_context_threshold_tokens' => 272_000,
-            'long_context_input_cost_per_1k' => 0.0004,
-            'long_context_output_cost_per_1k' => 0.0018,
-            'long_context_cache_read_cost_per_1k' => 0.00004,
-            'long_context_cache_write_cost_per_1k' => 0.0005,
             'supports_temperature' => false,
         ],
     ];
@@ -98,18 +91,10 @@ class BedrockService
 
             $latencyMs = $result['metrics']['latencyMs'] ?? null;
 
-            $totalInputTokens = $inputTokens + $cacheReadTokens + $cacheWriteTokens;
-            $isLongContext = isset($model['long_context_threshold_tokens']) && $totalInputTokens > $model['long_context_threshold_tokens'];
-
-            $inputRate = $isLongContext ? $model['long_context_input_cost_per_1k'] : $model['input_cost_per_1k'];
-            $outputRate = $isLongContext ? $model['long_context_output_cost_per_1k'] : $model['output_cost_per_1k'];
-            $cacheReadRate = ($isLongContext ? ($model['long_context_cache_read_cost_per_1k'] ?? null) : ($model['cache_read_cost_per_1k'] ?? null)) ?? $inputRate;
-            $cacheWriteRate = ($isLongContext ? ($model['long_context_cache_write_cost_per_1k'] ?? null) : ($model['cache_write_cost_per_1k'] ?? null)) ?? $inputRate;
-
-            $inputCost = ($inputTokens / 1000) * $inputRate;
-            $outputCost = ($outputTokens / 1000) * $outputRate;
-            $cacheReadCost = ($cacheReadTokens / 1000) * $cacheReadRate;
-            $cacheWriteCost = ($cacheWriteTokens / 1000) * $cacheWriteRate;
+            $inputCost = ($inputTokens / 1000) * $model['input_cost_per_1k'];
+            $outputCost = ($outputTokens / 1000) * $model['output_cost_per_1k'];
+            $cacheReadCost = ($cacheReadTokens / 1000) * ($model['cache_read_cost_per_1k'] ?? $model['input_cost_per_1k']);
+            $cacheWriteCost = ($cacheWriteTokens / 1000) * ($model['cache_write_cost_per_1k'] ?? $model['input_cost_per_1k']);
             $totalCost = $inputCost + $outputCost + $cacheReadCost + $cacheWriteCost;
 
             $metadata = [

--- a/src/Service/BedrockService.php
+++ b/src/Service/BedrockService.php
@@ -30,6 +30,10 @@ class BedrockService
             'input_cost_per_1k' => 0.0002,
             'output_cost_per_1k' => 0.0012,
             'supports_temperature' => false,
+            // Bedrock caches this model's prompts automatically (see invokeModel()). Per AWS
+            // docs, cache reads are a 90% discount off the input rate, cache writes are 1.25x.
+            'cache_read_cost_per_1k' => 0.00002,
+            'cache_write_cost_per_1k' => 0.00025,
         ],
     ];
 
@@ -68,26 +72,38 @@ class BedrockService
             $response = $this->bedrockClient->converse($requestBody + ['modelId' => $model['id']]);
 
             $result = $response->toArray();
-            $metadata = $result['@metadata'];
             $stopReason = $result['stopReason'] ?? null;
 
-            // For Converse API, token usage is in the 'usage' field, not headers
+            // Converse API response schema: usage.{inputTokens,outputTokens,cacheReadInputTokens,
+            // cacheWriteInputTokens} and metrics.latencyMs (NOT a response header - there is no
+            // such header on this API, the old header-based lookup always silently returned null).
+            // Bedrock applies prompt caching automatically for cache-capable models even without a
+            // cachePoint in the request - confirmed live via raw response inspection - so
+            // cacheReadInputTokens/cacheWriteInputTokens need their own (heavily discounted /
+            // premium, respectively) rates, otherwise cost is wildly under-reported: a 600-review
+            // summary regen showed inputTokens=2 with cacheReadInputTokens=58442, which the old
+            // code priced as if only 2 tokens of input existed.
             $usage = $result['usage'] ?? [];
             $inputTokens = $usage['inputTokens'] ?? 0;
             $outputTokens = $usage['outputTokens'] ?? 0;
+            $cacheReadTokens = $usage['cacheReadInputTokens'] ?? 0;
+            $cacheWriteTokens = $usage['cacheWriteInputTokens'] ?? 0;
 
-            // Latency might still be in headers
-            $latencyMs = $metadata['headers']['x-amzn-bedrock-invocation-latency'] ?? null;
+            $latencyMs = $result['metrics']['latencyMs'] ?? null;
 
             $inputCost = ($inputTokens / 1000) * $model['input_cost_per_1k'];
             $outputCost = ($outputTokens / 1000) * $model['output_cost_per_1k'];
-            $totalCost = $inputCost + $outputCost;
+            $cacheReadCost = ($cacheReadTokens / 1000) * ($model['cache_read_cost_per_1k'] ?? $model['input_cost_per_1k']);
+            $cacheWriteCost = ($cacheWriteTokens / 1000) * ($model['cache_write_cost_per_1k'] ?? $model['input_cost_per_1k']);
+            $totalCost = $inputCost + $outputCost + $cacheReadCost + $cacheWriteCost;
 
             $metadata = [
                 'model' => $model['id'],
                 'latency_ms' => $latencyMs,
                 'input_tokens' => $inputTokens,
                 'output_tokens' => $outputTokens,
+                'cache_read_tokens' => $cacheReadTokens,
+                'cache_write_tokens' => $cacheWriteTokens,
                 'cost_usd' => round($totalCost, 6),
                 'stop_reason' => $stopReason,
             ];
@@ -98,6 +114,8 @@ class BedrockService
                 'model_key' => $modelKey ?? $this->modelKey,
                 'input_tokens' => $inputTokens,
                 'output_tokens' => $outputTokens,
+                'cache_read_tokens' => $cacheReadTokens,
+                'cache_write_tokens' => $cacheWriteTokens,
                 'cost_usd' => round($totalCost, 6),
                 'latency_ms' => $latencyMs,
                 'stop_reason' => $stopReason,

--- a/src/Service/BedrockService.php
+++ b/src/Service/BedrockService.php
@@ -74,15 +74,10 @@ class BedrockService
             $result = $response->toArray();
             $stopReason = $result['stopReason'] ?? null;
 
-            // Converse API response schema: usage.{inputTokens,outputTokens,cacheReadInputTokens,
-            // cacheWriteInputTokens} and metrics.latencyMs (NOT a response header - there is no
-            // such header on this API, the old header-based lookup always silently returned null).
-            // Bedrock applies prompt caching automatically for cache-capable models even without a
-            // cachePoint in the request - confirmed live via raw response inspection - so
-            // cacheReadInputTokens/cacheWriteInputTokens need their own (heavily discounted /
-            // premium, respectively) rates, otherwise cost is wildly under-reported: a 600-review
-            // summary regen showed inputTokens=2 with cacheReadInputTokens=58442, which the old
-            // code priced as if only 2 tokens of input existed.
+            // latencyMs lives under metrics, not a response header. Bedrock applies prompt
+            // caching automatically for cache-capable models with no cachePoint required, so
+            // cacheReadInputTokens/cacheWriteInputTokens need their own rates below - otherwise
+            // a cache hit reports as if almost no input tokens were used at all.
             $usage = $result['usage'] ?? [];
             $inputTokens = $usage['inputTokens'] ?? 0;
             $outputTokens = $usage['outputTokens'] ?? 0;

--- a/src/Service/CoasterSummaryService.php
+++ b/src/Service/CoasterSummaryService.php
@@ -338,10 +338,7 @@ class CoasterSummaryService
      */
     private function buildPrompt(array $riddenCoasters, string $coasterName, ?Coaster $coaster, string $language = 'en'): string
     {
-        // Sanitize coaster name to prevent prompt injection. \w alone is ASCII-only, which
-        // was silently mangling accented names ("Titánide" -> "Titnide") for the ~300
-        // coasters with non-ASCII characters - \p{L}/\p{N} keep any Unicode letter/digit.
-        $sanitizedName = preg_replace('/[^\p{L}\p{N}\s\-]/u', '', $coasterName);
+        $sanitizedName = PromptNameSanitizer::sanitize($coasterName);
         $reviewCount = \count($riddenCoasters);
 
         // Language-specific instructions

--- a/src/Service/CoasterSummaryService.php
+++ b/src/Service/CoasterSummaryService.php
@@ -352,7 +352,7 @@ class CoasterSummaryService
             'de' => 'German',
         ];
         $languageName = $languageNames[$language] ?? 'English';
-        $outputLanguageInstruction = "Write the summary and pros/cons in natural, fluent {$languageName}, as if written by a native speaker enthusiast. Some source reviews below may be written in other languages — read them for content and sentiment, but always respond in {$languageName}.";
+        $outputLanguageInstruction = "Write the summary and pros/cons in natural, fluent {$languageName}, as if written by a native speaker enthusiast. Some source reviews below may be written in other languages — read them for content and sentiment, but always respond in {$languageName}. When a source review uses enthusiast slang or jargon that has no natural equivalent in {$languageName}, convey the sensation it describes rather than translating it word-for-word.";
 
         $prompt = "You are an expert roller coaster analyst with deep knowledge of ride experiences and enthusiast terminology. Your task is to analyze rider reviews for {$sanitizedName} and create an objective, balanced summary that helps future riders make informed decisions.\n\n";
 

--- a/src/Service/CoasterSummaryService.php
+++ b/src/Service/CoasterSummaryService.php
@@ -338,8 +338,10 @@ class CoasterSummaryService
      */
     private function buildPrompt(array $riddenCoasters, string $coasterName, ?Coaster $coaster, string $language = 'en'): string
     {
-        // Sanitize coaster name to prevent prompt injection
-        $sanitizedName = preg_replace('/[^\w\s-]/', '', $coasterName);
+        // Sanitize coaster name to prevent prompt injection. \w alone is ASCII-only, which
+        // was silently mangling accented names ("Titánide" -> "Titnide") for the ~300
+        // coasters with non-ASCII characters - \p{L}/\p{N} keep any Unicode letter/digit.
+        $sanitizedName = preg_replace('/[^\p{L}\p{N}\s\-]/u', '', $coasterName);
         $reviewCount = \count($riddenCoasters);
 
         // Language-specific instructions

--- a/src/Service/PromptNameSanitizer.php
+++ b/src/Service/PromptNameSanitizer.php
@@ -13,9 +13,7 @@ final class PromptNameSanitizer
 {
     public static function sanitize(string $name): string
     {
-        // preg_replace with the /u modifier returns null (not the original string) when
-        // given malformed UTF-8, instead of throwing - fall back to the original name
-        // rather than silently dropping it from the prompt.
+        // preg_replace returns null (not the input) on malformed UTF-8 with /u.
         return preg_replace('/[^\p{L}\p{N}\s\-]/u', '', $name) ?? $name;
     }
 }

--- a/src/Service/PromptNameSanitizer.php
+++ b/src/Service/PromptNameSanitizer.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+/**
+ * Strips characters that could be used for prompt injection from a name before it's
+ * interpolated into an AI prompt, while preserving any Unicode letter/digit (accents
+ * included).
+ */
+final class PromptNameSanitizer
+{
+    public static function sanitize(string $name): string
+    {
+        // preg_replace with the /u modifier returns null (not the original string) when
+        // given malformed UTF-8, instead of throwing - fall back to the original name
+        // rather than silently dropping it from the prompt.
+        return preg_replace('/[^\p{L}\p{N}\s\-]/u', '', $name) ?? $name;
+    }
+}

--- a/src/Service/ReviewModerationService.php
+++ b/src/Service/ReviewModerationService.php
@@ -77,9 +77,7 @@ class ReviewModerationService
 
     private function buildPrompt(RiddenCoaster $review): string
     {
-        // \w alone is ASCII-only and silently mangles accented coaster names - \p{L}/\p{N}
-        // with /u keep any Unicode letter/digit.
-        $sanitizedCoasterName = preg_replace('/[^\p{L}\p{N}\s\-]/u', '', $review->getCoaster()->getName());
+        $sanitizedCoasterName = PromptNameSanitizer::sanitize($review->getCoaster()->getName());
 
         $prompt = "You are a content moderator for a roller coaster review website. Analyze the following review and respond with strict JSON only.\n\n";
         $prompt .= "<review>\n";

--- a/src/Service/ReviewModerationService.php
+++ b/src/Service/ReviewModerationService.php
@@ -77,7 +77,9 @@ class ReviewModerationService
 
     private function buildPrompt(RiddenCoaster $review): string
     {
-        $sanitizedCoasterName = preg_replace('/[^\w\s-]/', '', $review->getCoaster()->getName());
+        // \w alone is ASCII-only and silently mangles accented coaster names - \p{L}/\p{N}
+        // with /u keep any Unicode letter/digit.
+        $sanitizedCoasterName = preg_replace('/[^\p{L}\p{N}\s\-]/u', '', $review->getCoaster()->getName());
 
         $prompt = "You are a content moderator for a roller coaster review website. Analyze the following review and respond with strict JSON only.\n\n";
         $prompt .= "<review>\n";
@@ -89,11 +91,11 @@ class ReviewModerationService
         $prompt .= "1. Detect the language of the review text and return its ISO 639-1 code (e.g. \"en\", \"fr\", \"ja\", \"sv\").\n";
         $prompt .= "2. Classify the review into exactly one category:\n";
         $prompt .= "   - \"ok\": on-topic opinion about the ride itself — any ride characteristic: sensations, look, operations, etc. Light profanity (e.g. \"crap\", \"sucks\", \"shit\", \"damn\") is fine as part of a genuine review.\n";
-        $prompt .= "   - \"toxic\": hostility or insults aimed at people (staff, management, reviewers). Light profanity is only ok as part of a genuine on-topic review of the ride — without real ride content behind it, light profanity is toxic. Heavy profanity (e.g. \"fuck\"/\"fucking\", slurs, graphic/extreme language) is always toxic, regardless of context.\n";
+        $prompt .= "   - \"toxic\": hostility or insults aimed at people (staff, management, reviewers) — never the ride itself. A blunt or harshly negative opinion about the ride (e.g. \"Horrendous\", \"this thing is a disaster, no interest at all\") is \"ok\", not toxic, as long as it targets no person and contains no real profanity — bluntness or brevity alone is not toxicity. Light profanity is only ok as part of a genuine on-topic review of the ride — without real ride content behind it, light profanity is toxic. Heavy profanity (e.g. \"fuck\"/\"fucking\", slurs, graphic/extreme language) is always toxic, regardless of context.\n";
         $prompt .= "   - \"spam\": promotional content, gibberish, or repeated/copy-pasted text.\n";
-        $prompt .= "   - \"troll\": bad-faith, disruptive, or nonsensical content with no genuine opinion behind it. Jokes and exaggerated humor are NOT troll if they express a real (if hyperbolic) sentiment about the ride (e.g. \"life is short, let's not make it shorter by riding this\" = the ride feels intense) — only flag troll when there's no real view behind it, or it's meant to disrupt/mislead.\n";
-        $prompt .= "   - \"offtopic\": not about the ride experience or general park experience. Includes: safety incident reports, formal complaints, legal/financial grievances with management. Does NOT include: physical reactions to the ride, staff/service quality opinions, or ride mechanics/experience descriptions even with strong language.\n";
-        $prompt .= "   - \"not_ridden\": the reviewer explicitly states they have not ridden the coaster. Do not infer this from tone, appearance-only comments, or anticipation — only flag when stated directly.\n";
+        $prompt .= "   - \"troll\": bad-faith, disruptive, or nonsensical content with no genuine opinion behind it. Jokes and exaggerated humor are \"ok\", NOT troll, if they express a real (if hyperbolic) sentiment about the ride — e.g. \"life is short, let's not make it shorter by riding this\" genuinely means the ride feels intense/scary, so classify it \"ok\". Only use troll when there is no real view behind the text, or it is meant to disrupt/mislead.\n";
+        $prompt .= "   - \"offtopic\": not about the ride experience or general park experience. Includes: formal complaints or legal/financial grievances with management, incidents unrelated to the normal ride experience (e.g. a fall, an altercation with other guests, an evacuation). Does NOT include physical reactions to the ride itself — aches, bruises, motion sickness, fear — even when described as an injury or in strong language; those are core review content, not offtopic. Also does not include staff/service quality opinions or ride mechanics/experience descriptions.\n";
+        $prompt .= "   - \"not_ridden\": the reviewer explicitly states they have not ridden the coaster (e.g. \"I never got to ride this\"). Do not infer this from tone, brevity, appearance-only comments, or anticipation of a future visit — a terse or exterior-only comment is still a real (if thin) opinion, not evidence the reviewer skipped the ride. When it's ambiguous, do not flag.\n";
         $prompt .= "   - \"other\": clearly problematic but doesn't fit the categories above.\n";
         $prompt .= "3. Rate your confidence in the category as \"low\", \"medium\", or \"high\".\n";
         $prompt .= "4. If category is not \"ok\", give a one-sentence explanation in English for a human moderator. If category is \"ok\", explanation must be null.\n";

--- a/tests/Command/GenerateCoasterSummariesCommandTest.php
+++ b/tests/Command/GenerateCoasterSummariesCommandTest.php
@@ -213,8 +213,6 @@ class GenerateCoasterSummariesCommandTest extends TestCase
         $this->summaryService->method('generateSummary')
             ->willReturn(['summary' => null, 'metadata' => null, 'reason' => 'insufficient_reviews', 'review_count' => 3]);
 
-        // CoasterSummaryService::runAnalysis() already logs this at info level - the
-        // command must not log it a second time, nor escalate it to error.
         $this->logger->expects($this->never())->method('error');
         $this->logger->expects($this->never())->method('info');
 

--- a/tests/Command/GenerateCoasterSummariesCommandTest.php
+++ b/tests/Command/GenerateCoasterSummariesCommandTest.php
@@ -204,7 +204,7 @@ class GenerateCoasterSummariesCommandTest extends TestCase
         $this->assertStringNotContainsString('Skipping', $output);
     }
 
-    public function testInsufficientReviewsLogsAtInfoNotError(): void
+    public function testInsufficientReviewsDoesNotLogAtCommandLevel(): void
     {
         $coaster = new Coaster();
         $coaster->setName('Test Coaster');
@@ -213,10 +213,10 @@ class GenerateCoasterSummariesCommandTest extends TestCase
         $this->summaryService->method('generateSummary')
             ->willReturn(['summary' => null, 'metadata' => null, 'reason' => 'insufficient_reviews', 'review_count' => 3]);
 
+        // CoasterSummaryService::runAnalysis() already logs this at info level - the
+        // command must not log it a second time, nor escalate it to error.
         $this->logger->expects($this->never())->method('error');
-        $this->logger->expects($this->once())
-            ->method('info')
-            ->with('Skipped: insufficient reviews', $this->anything());
+        $this->logger->expects($this->never())->method('info');
 
         $this->commandTester->execute(['--coaster-id' => '123']);
     }

--- a/tests/Command/GenerateCoasterSummariesCommandTest.php
+++ b/tests/Command/GenerateCoasterSummariesCommandTest.php
@@ -204,6 +204,39 @@ class GenerateCoasterSummariesCommandTest extends TestCase
         $this->assertStringNotContainsString('Skipping', $output);
     }
 
+    public function testInsufficientReviewsLogsAtInfoNotError(): void
+    {
+        $coaster = new Coaster();
+        $coaster->setName('Test Coaster');
+
+        $this->coasterRepository->method('find')->willReturn($coaster);
+        $this->summaryService->method('generateSummary')
+            ->willReturn(['summary' => null, 'metadata' => null, 'reason' => 'insufficient_reviews', 'review_count' => 3]);
+
+        $this->logger->expects($this->never())->method('error');
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with('Skipped: insufficient reviews', $this->anything());
+
+        $this->commandTester->execute(['--coaster-id' => '123']);
+    }
+
+    public function testAiErrorStillLogsAtErrorLevel(): void
+    {
+        $coaster = new Coaster();
+        $coaster->setName('Test Coaster');
+
+        $this->coasterRepository->method('find')->willReturn($coaster);
+        $this->summaryService->method('generateSummary')
+            ->willReturn(['summary' => null, 'metadata' => null, 'reason' => 'ai_error']);
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with('Failed to generate summary', $this->anything());
+
+        $this->commandTester->execute(['--coaster-id' => '123']);
+    }
+
     public function testInvalidCoasterIdReturnsError(): void
     {
         $this->coasterRepository

--- a/tests/Service/BedrockServiceTest.php
+++ b/tests/Service/BedrockServiceTest.php
@@ -246,61 +246,6 @@ class BedrockServiceTest extends TestCase
         $this->assertGreaterThan((503 / 1000) * 0.0012, $result['metadata']['cost_usd']);
     }
 
-    public function testLongContextTierUsesItsOwnRatesNotAFlatMultiplier(): void
-    {
-        $bedrockClient = $this->createConverseSpyClient();
-        $logger = $this->createMock(LoggerInterface::class);
-        $service = new BedrockService($bedrockClient, $logger, 'gpt-5.6-luna');
-
-        // Total input tokens (input + cache read + cache write) over the 272,000 threshold.
-        $mockResult = $this->createMock(Result::class);
-        $mockResult->method('toArray')->willReturn([
-            'output' => ['message' => ['content' => [['text' => 'x']]]],
-            'usage' => [
-                'inputTokens' => 300_000,
-                'outputTokens' => 1000,
-                'cacheReadInputTokens' => 0,
-                'cacheWriteInputTokens' => 0,
-            ],
-            'metrics' => ['latencyMs' => 1000],
-            '@metadata' => ['headers' => []],
-        ]);
-        $bedrockClient->setMockResult($mockResult);
-
-        $result = $service->invokeModel('prompt', 'gpt-5.6-luna', 500, 0.5);
-
-        // Input doubles (0.0002 -> 0.0004) but output only rises 1.5x (0.0012 -> 0.0018) -
-        // the two rates aren't a single flat multiplier, per the model's real pricing table.
-        $expectedCost = (300_000 / 1000) * 0.0004 + (1000 / 1000) * 0.0018;
-        $this->assertEqualsWithDelta(round($expectedCost, 6), $result['metadata']['cost_usd'], 0.0000001);
-    }
-
-    public function testBelowLongContextThresholdUsesShortContextRates(): void
-    {
-        $bedrockClient = $this->createConverseSpyClient();
-        $logger = $this->createMock(LoggerInterface::class);
-        $service = new BedrockService($bedrockClient, $logger, 'gpt-5.6-luna');
-
-        $mockResult = $this->createMock(Result::class);
-        $mockResult->method('toArray')->willReturn([
-            'output' => ['message' => ['content' => [['text' => 'x']]]],
-            'usage' => [
-                'inputTokens' => 271_999,
-                'outputTokens' => 1000,
-                'cacheReadInputTokens' => 0,
-                'cacheWriteInputTokens' => 0,
-            ],
-            'metrics' => ['latencyMs' => 1000],
-            '@metadata' => ['headers' => []],
-        ]);
-        $bedrockClient->setMockResult($mockResult);
-
-        $result = $service->invokeModel('prompt', 'gpt-5.6-luna', 500, 0.5);
-
-        $expectedCost = (271_999 / 1000) * 0.0002 + (1000 / 1000) * 0.0012;
-        $this->assertEqualsWithDelta(round($expectedCost, 6), $result['metadata']['cost_usd'], 0.0000001);
-    }
-
     public function testInvokeModelReturnsClearErrorForUnknownModelKey(): void
     {
         $bedrockClient = $this->createConverseSpyClient();

--- a/tests/Service/BedrockServiceTest.php
+++ b/tests/Service/BedrockServiceTest.php
@@ -24,7 +24,7 @@ interface ConverseSpyClient
 }
 
 /**
- * **Feature: coaster-summary-refactor, Property 3: Unified Bedrock API Interface**
+ * **Feature: coaster-summary-refactor, Property 3: Unified Bedrock API Interface**.
  *
  * Tests that the BedrockService uses the same Converse API request format
  * and response parsing method regardless of the underlying model.
@@ -35,7 +35,7 @@ class BedrockServiceTest extends TestCase
 
     /**
      * **Property 3: Unified Bedrock API Interface**
-     * **Validates: Requirements 3.2, 3.3, 3.4, 3.5**
+     * **Validates: Requirements 3.2, 3.3, 3.4, 3.5**.
      *
      * For any supported Bedrock model (GPT OSS, GPT-5.6 Luna),
      * the BedrockService should use the same Converse API request format
@@ -50,7 +50,7 @@ class BedrockServiceTest extends TestCase
             Generator\choose(100, 2000), // @phpstan-ignore-line
             Generator\float(0.0, 1.0) // @phpstan-ignore-line
         )
-        ->then(function (string $model, string $prompt, int $maxTokens, float $temperature) {
+        ->then(function (string $model, string $prompt, int $maxTokens, float $temperature): void {
             $bedrockClient = $this->createConverseSpyClient();
 
             $logger = $this->createMock(LoggerInterface::class);
@@ -103,15 +103,14 @@ class BedrockServiceTest extends TestCase
                 ],
             ],
             'usage' => [
-                'inputTokens' => rand(50, 200),
-                'outputTokens' => rand(20, 100),
+                'inputTokens' => random_int(50, 200),
+                'outputTokens' => random_int(20, 100),
+            ],
+            'metrics' => [
+                'latencyMs' => random_int(100, 1000),
             ],
             '@metadata' => [
-                'headers' => [
-                    'x-amzn-bedrock-invocation-latency' => rand(100, 1000),
-                    'x-amzn-bedrock-input-token-count' => rand(50, 200),
-                    'x-amzn-bedrock-output-token-count' => rand(20, 100),
-                ],
+                'headers' => [],
             ],
         ];
 
@@ -191,6 +190,60 @@ class BedrockServiceTest extends TestCase
         $result = $service->invokeModel('prompt', 'gpt-oss-120b', 1000, 0.5);
 
         $this->assertSame('max_tokens', $result['metadata']['stop_reason']);
+    }
+
+    public function testLatencyIsReadFromMetricsField(): void
+    {
+        $bedrockClient = $this->createConverseSpyClient();
+        $logger = $this->createMock(LoggerInterface::class);
+        $service = new BedrockService($bedrockClient, $logger, 'gpt-oss-120b');
+
+        $mockResult = $this->createMock(Result::class);
+        $mockResult->method('toArray')->willReturn([
+            'output' => ['message' => ['content' => [['text' => 'x']]]],
+            'usage' => ['inputTokens' => 10, 'outputTokens' => 5],
+            'metrics' => ['latencyMs' => 1234],
+            '@metadata' => ['headers' => []],
+        ]);
+        $bedrockClient->setMockResult($mockResult);
+
+        $result = $service->invokeModel('prompt', 'gpt-oss-120b', 500, 0.5);
+
+        $this->assertSame(1234, $result['metadata']['latency_ms']);
+    }
+
+    public function testCacheTokensAreCostedAtTheirOwnRates(): void
+    {
+        $bedrockClient = $this->createConverseSpyClient();
+        $logger = $this->createMock(LoggerInterface::class);
+        $service = new BedrockService($bedrockClient, $logger, 'gpt-5.6-luna');
+
+        $mockResult = $this->createMock(Result::class);
+        $mockResult->method('toArray')->willReturn([
+            'output' => ['message' => ['content' => [['text' => 'x']]]],
+            'usage' => [
+                'inputTokens' => 2,
+                'outputTokens' => 503,
+                'cacheReadInputTokens' => 58442,
+                'cacheWriteInputTokens' => 0,
+            ],
+            'metrics' => ['latencyMs' => 3942],
+            '@metadata' => ['headers' => []],
+        ]);
+        $bedrockClient->setMockResult($mockResult);
+
+        $result = $service->invokeModel('prompt', 'gpt-5.6-luna', 500, 0.5);
+
+        $this->assertSame(58442, $result['metadata']['cache_read_tokens']);
+        $this->assertSame(0, $result['metadata']['cache_write_tokens']);
+
+        // (2/1000)*0.0002 + (503/1000)*0.0012 + (58442/1000)*0.00002 + 0
+        $expectedCost = (2 / 1000) * 0.0002 + (503 / 1000) * 0.0012 + (58442 / 1000) * 0.00002;
+        $this->assertEqualsWithDelta(round($expectedCost, 6), $result['metadata']['cost_usd'], 0.0000001);
+
+        // Cost dominated by cache reads, not the misleadingly tiny "2" input tokens -
+        // this is exactly the case the old code under-reported.
+        $this->assertGreaterThan((503 / 1000) * 0.0012, $result['metadata']['cost_usd']);
     }
 
     public function testInvokeModelReturnsClearErrorForUnknownModelKey(): void

--- a/tests/Service/BedrockServiceTest.php
+++ b/tests/Service/BedrockServiceTest.php
@@ -246,6 +246,61 @@ class BedrockServiceTest extends TestCase
         $this->assertGreaterThan((503 / 1000) * 0.0012, $result['metadata']['cost_usd']);
     }
 
+    public function testLongContextTierUsesItsOwnRatesNotAFlatMultiplier(): void
+    {
+        $bedrockClient = $this->createConverseSpyClient();
+        $logger = $this->createMock(LoggerInterface::class);
+        $service = new BedrockService($bedrockClient, $logger, 'gpt-5.6-luna');
+
+        // Total input tokens (input + cache read + cache write) over the 272,000 threshold.
+        $mockResult = $this->createMock(Result::class);
+        $mockResult->method('toArray')->willReturn([
+            'output' => ['message' => ['content' => [['text' => 'x']]]],
+            'usage' => [
+                'inputTokens' => 300_000,
+                'outputTokens' => 1000,
+                'cacheReadInputTokens' => 0,
+                'cacheWriteInputTokens' => 0,
+            ],
+            'metrics' => ['latencyMs' => 1000],
+            '@metadata' => ['headers' => []],
+        ]);
+        $bedrockClient->setMockResult($mockResult);
+
+        $result = $service->invokeModel('prompt', 'gpt-5.6-luna', 500, 0.5);
+
+        // Input doubles (0.0002 -> 0.0004) but output only rises 1.5x (0.0012 -> 0.0018) -
+        // the two rates aren't a single flat multiplier, per the model's real pricing table.
+        $expectedCost = (300_000 / 1000) * 0.0004 + (1000 / 1000) * 0.0018;
+        $this->assertEqualsWithDelta(round($expectedCost, 6), $result['metadata']['cost_usd'], 0.0000001);
+    }
+
+    public function testBelowLongContextThresholdUsesShortContextRates(): void
+    {
+        $bedrockClient = $this->createConverseSpyClient();
+        $logger = $this->createMock(LoggerInterface::class);
+        $service = new BedrockService($bedrockClient, $logger, 'gpt-5.6-luna');
+
+        $mockResult = $this->createMock(Result::class);
+        $mockResult->method('toArray')->willReturn([
+            'output' => ['message' => ['content' => [['text' => 'x']]]],
+            'usage' => [
+                'inputTokens' => 271_999,
+                'outputTokens' => 1000,
+                'cacheReadInputTokens' => 0,
+                'cacheWriteInputTokens' => 0,
+            ],
+            'metrics' => ['latencyMs' => 1000],
+            '@metadata' => ['headers' => []],
+        ]);
+        $bedrockClient->setMockResult($mockResult);
+
+        $result = $service->invokeModel('prompt', 'gpt-5.6-luna', 500, 0.5);
+
+        $expectedCost = (271_999 / 1000) * 0.0002 + (1000 / 1000) * 0.0012;
+        $this->assertEqualsWithDelta(round($expectedCost, 6), $result['metadata']['cost_usd'], 0.0000001);
+    }
+
     public function testInvokeModelReturnsClearErrorForUnknownModelKey(): void
     {
         $bedrockClient = $this->createConverseSpyClient();

--- a/tests/Service/BedrockServiceTest.php
+++ b/tests/Service/BedrockServiceTest.php
@@ -237,12 +237,8 @@ class BedrockServiceTest extends TestCase
         $this->assertSame(58442, $result['metadata']['cache_read_tokens']);
         $this->assertSame(0, $result['metadata']['cache_write_tokens']);
 
-        // (2/1000)*0.0002 + (503/1000)*0.0012 + (58442/1000)*0.00002 + 0
         $expectedCost = (2 / 1000) * 0.0002 + (503 / 1000) * 0.0012 + (58442 / 1000) * 0.00002;
         $this->assertEqualsWithDelta(round($expectedCost, 6), $result['metadata']['cost_usd'], 0.0000001);
-
-        // Cost dominated by cache reads, not the misleadingly tiny "2" input tokens -
-        // this is exactly the case the old code under-reported.
         $this->assertGreaterThan((503 / 1000) * 0.0012, $result['metadata']['cost_usd']);
     }
 

--- a/tests/Service/CoasterSummaryServiceTest.php
+++ b/tests/Service/CoasterSummaryServiceTest.php
@@ -207,6 +207,27 @@ class CoasterSummaryServiceTest extends TestCase
     }
 
     /**
+     * Test prompt preserves accented/non-ASCII characters in coaster names.
+     * \w alone is ASCII-only and was silently stripping accents (e.g. "Titánide" ->
+     * "Titnide") for the ~300 coasters with non-ASCII characters in their name.
+     */
+    public function testPromptPreservesAccentedCoasterNames(): void
+    {
+        $service = $this->createCoasterSummaryService();
+        $buildPromptMethod = $this->getPrivateMethod($service, 'buildPrompt');
+
+        $coaster = new Coaster();
+        $coaster->setName('Titánide');
+
+        $reviews = [$this->createRiddenCoaster($coaster, 7.0, 'Bon manège')];
+
+        $prompt = $buildPromptMethod->invoke($service, $reviews, 'Titánide', $coaster, 'fr');
+
+        $this->assertStringContainsString('Titánide', $prompt);
+        $this->assertStringNotContainsString('Titnide', $prompt);
+    }
+
+    /**
      * Test prompt includes proper language-specific instructions.
      * Requirements: Multi-language support.
      */

--- a/tests/Service/CoasterSummaryServiceTest.php
+++ b/tests/Service/CoasterSummaryServiceTest.php
@@ -208,8 +208,7 @@ class CoasterSummaryServiceTest extends TestCase
 
     /**
      * Test prompt preserves accented/non-ASCII characters in coaster names.
-     * \w alone is ASCII-only and was silently stripping accents (e.g. "Titánide" ->
-     * "Titnide") for the ~300 coasters with non-ASCII characters in their name.
+     * Requirements: Security.
      */
     public function testPromptPreservesAccentedCoasterNames(): void
     {

--- a/tests/Service/PromptNameSanitizerTest.php
+++ b/tests/Service/PromptNameSanitizerTest.php
@@ -23,8 +23,6 @@ class PromptNameSanitizerTest extends TestCase
 
     public function testFallsBackToOriginalStringOnInvalidUtf8(): void
     {
-        // preg_replace with the /u modifier returns null (not the input) on malformed
-        // UTF-8, instead of throwing - this must not silently blank the name.
         $invalidUtf8 = "Vol\xB1ge";
 
         $this->assertSame($invalidUtf8, PromptNameSanitizer::sanitize($invalidUtf8));

--- a/tests/Service/PromptNameSanitizerTest.php
+++ b/tests/Service/PromptNameSanitizerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Service\PromptNameSanitizer;
+use PHPUnit\Framework\TestCase;
+
+class PromptNameSanitizerTest extends TestCase
+{
+    public function testPreservesAccentedCharacters(): void
+    {
+        $this->assertSame('Titánide', PromptNameSanitizer::sanitize('Titánide'));
+    }
+
+    public function testStripsInjectionCharacters(): void
+    {
+        $sanitized = PromptNameSanitizer::sanitize('Test<script>alert("xss")</script>Coaster');
+
+        $this->assertSame('TestscriptalertxssscriptCoaster', $sanitized);
+    }
+
+    public function testFallsBackToOriginalStringOnInvalidUtf8(): void
+    {
+        // preg_replace with the /u modifier returns null (not the input) on malformed
+        // UTF-8, instead of throwing - this must not silently blank the name.
+        $invalidUtf8 = "Vol\xB1ge";
+
+        $this->assertSame($invalidUtf8, PromptNameSanitizer::sanitize($invalidUtf8));
+    }
+}

--- a/tests/Service/ReviewModerationServiceTest.php
+++ b/tests/Service/ReviewModerationServiceTest.php
@@ -190,6 +190,26 @@ class ReviewModerationServiceTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testBuildPromptPreservesAccentedCoasterNames(): void
+    {
+        $coaster = new Coaster();
+        $coaster->setName('Titánide');
+
+        $review = new RiddenCoaster();
+        $review->setCoaster($coaster);
+        $review->setValue(3.0);
+        $review->setReview('Bon manège');
+
+        $service = new ReviewModerationService($this->createMock(BedrockService::class), $this->createMock(LoggerInterface::class));
+
+        $reflection = new \ReflectionClass($service);
+        $buildPrompt = $reflection->getMethod('buildPrompt');
+        $prompt = $buildPrompt->invoke($service, $review);
+
+        $this->assertStringContainsString('Titánide', $prompt);
+        $this->assertStringNotContainsString('Titnide', $prompt);
+    }
+
     public function testAnalyzeAcceptsNotRiddenCategory(): void
     {
         $bedrockService = $this->createMock(BedrockService::class);


### PR DESCRIPTION
## Summary
**Coaster summaries:**
- Fix accent-stripping bug in `CoasterSummaryService::buildPrompt()` - `\w` is ASCII-only and was silently mangling coaster names (e.g. "Titánide" -> "Titnide") in ~41 live summaries.
- Split CLI failure logging by reason: `insufficient_reviews` now logs at `info`, not `error` - this was paging Discord for routine, expected skips.
- Instruct the model to convey the sensation of enthusiast slang rather than translate it word-for-word, after finding "whip"/"whippy" literally translated to "fouetté" in backfilled FR summaries.

**Moderation:**
- Reviewed 32 recently-resolved AI moderation reports against real human moderator decisions and found the model contradicting its own prompt rules on `troll`, `not_ridden`, `toxic`, and `offtopic`. Reworded each rule and re-verified against the exact false-positive examples plus true-positive checks.
- Fixes the same accent-stripping bug in the moderation prompt.

**Bedrock service (latency/cost reporting):**
- `latency_ms` was always null - the code read a response header that doesn't exist on the Converse API; fixed to read the documented `metrics.latencyMs` field.
- Live inspection of raw Converse responses revealed Bedrock applies automatic prompt caching for `gpt-5.6-luna` even with no `cachePoint` in the request. The old cost math ignored `cacheReadInputTokens`/`cacheWriteInputTokens` entirely, under-reporting real cost by ~8x on cache-write calls (verified live: $0.0107 actual vs. ~$0.0006 as previously shown). Added per-model cache pricing and surfaced cache token counts in CLI output.

All three areas came out of the same audit pass (using a fresh production DB dump and live Bedrock calls) into why AI summaries/moderation looked degraded and why cost/perf metrics looked off - grouped into one PR since they share root cause and verification method.

## Test plan
- [x] `vendor/bin/phpunit` (full suite, 163 tests)
- [x] `vendor/bin/phpstan analyse` (full codebase)
- [x] Verified against real mangled prod examples ("Titánide", "Souris Mécaniques")
- [x] Re-ran all 4 moderation false-positive examples live - all now classify `ok`; re-ran true-positive checks - still correctly flagged
- [x] Verified latency/cache fix live via `app:compare-summary-models` - real latency values now shown, cache-write vs cache-read cost difference now correctly reflected

🤖 Generated with [Claude Code](https://claude.com/claude-code)