### PR TITLE
fix(moderation): recalibrate toxic/troll/offtopic/not_ridden rules

### DIFF
--- a/src/Service/ReviewModerationService.php
+++ b/src/Service/ReviewModerationService.php
@@ -77,7 +77,9 @@ class ReviewModerationService
 
     private function buildPrompt(RiddenCoaster $review): string
     {
-        $sanitizedCoasterName = preg_replace('/[^\w\s-]/', '', $review->getCoaster()->getName());
+        // \w alone is ASCII-only and silently mangles accented coaster names - \p{L}/\p{N}
+        // with /u keep any Unicode letter/digit.
+        $sanitizedCoasterName = preg_replace('/[^\p{L}\p{N}\s\-]/u', '', $review->getCoaster()->getName());
 
         $prompt = "You are a content moderator for a roller coaster review website. Analyze the following review and respond with strict JSON only.\n\n";
         $prompt .= "<review>\n";
@@ -89,11 +91,11 @@ class ReviewModerationService
         $prompt .= "1. Detect the language of the review text and return its ISO 639-1 code (e.g. \"en\", \"fr\", \"ja\", \"sv\").\n";
         $prompt .= "2. Classify the review into exactly one category:\n";
         $prompt .= "   - \"ok\": on-topic opinion about the ride itself — any ride characteristic: sensations, look, operations, etc. Light profanity (e.g. \"crap\", \"sucks\", \"shit\", \"damn\") is fine as part of a genuine review.\n";
-        $prompt .= "   - \"toxic\": hostility or insults aimed at people (staff, management, reviewers). Light profanity is only ok as part of a genuine on-topic review of the ride — without real ride content behind it, light profanity is toxic. Heavy profanity (e.g. \"fuck\"/\"fucking\", slurs, graphic/extreme language) is always toxic, regardless of context.\n";
+        $prompt .= "   - \"toxic\": hostility or insults aimed at people (staff, management, reviewers) — never the ride itself. A blunt or harshly negative opinion about the ride (e.g. \"Horrendous\", \"this thing is a disaster, no interest at all\") is \"ok\", not toxic, as long as it targets no person and contains no real profanity — bluntness or brevity alone is not toxicity. Light profanity is only ok as part of a genuine on-topic review of the ride — without real ride content behind it, light profanity is toxic. Heavy profanity (e.g. \"fuck\"/\"fucking\", slurs, graphic/extreme language) is always toxic, regardless of context.\n";
         $prompt .= "   - \"spam\": promotional content, gibberish, or repeated/copy-pasted text.\n";
-        $prompt .= "   - \"troll\": bad-faith, disruptive, or nonsensical content with no genuine opinion behind it. Jokes and exaggerated humor are NOT troll if they express a real (if hyperbolic) sentiment about the ride (e.g. \"life is short, let's not make it shorter by riding this\" = the ride feels intense) — only flag troll when there's no real view behind it, or it's meant to disrupt/mislead.\n";
-        $prompt .= "   - \"offtopic\": not about the ride experience or general park experience. Includes: safety incident reports, formal complaints, legal/financial grievances with management. Does NOT include: physical reactions to the ride, staff/service quality opinions, or ride mechanics/experience descriptions even with strong language.\n";
-        $prompt .= "   - \"not_ridden\": the reviewer explicitly states they have not ridden the coaster. Do not infer this from tone, appearance-only comments, or anticipation — only flag when stated directly.\n";
+        $prompt .= "   - \"troll\": bad-faith, disruptive, or nonsensical content with no genuine opinion behind it. Jokes and exaggerated humor are \"ok\", NOT troll, if they express a real (if hyperbolic) sentiment about the ride — e.g. \"life is short, let's not make it shorter by riding this\" genuinely means the ride feels intense/scary, so classify it \"ok\". Only use troll when there is no real view behind the text, or it is meant to disrupt/mislead.\n";
+        $prompt .= "   - \"offtopic\": not about the ride experience or general park experience. Includes: formal complaints or legal/financial grievances with management, incidents unrelated to the normal ride experience (e.g. a fall, an altercation with other guests, an evacuation). Does NOT include physical reactions to the ride itself — aches, bruises, motion sickness, fear — even when described as an injury or in strong language; those are core review content, not offtopic. Also does not include staff/service quality opinions or ride mechanics/experience descriptions.\n";
+        $prompt .= "   - \"not_ridden\": the reviewer explicitly states they have not ridden the coaster (e.g. \"I never got to ride this\"). Do not infer this from tone, brevity, appearance-only comments, or anticipation of a future visit — a terse or exterior-only comment is still a real (if thin) opinion, not evidence the reviewer skipped the ride. When it's ambiguous, do not flag.\n";
         $prompt .= "   - \"other\": clearly problematic but doesn't fit the categories above.\n";
         $prompt .= "3. Rate your confidence in the category as \"low\", \"medium\", or \"high\".\n";
         $prompt .= "4. If category is not \"ok\", give a one-sentence explanation in English for a human moderator. If category is \"ok\", explanation must be null.\n";

--- a/tests/Service/ReviewModerationServiceTest.php
+++ b/tests/Service/ReviewModerationServiceTest.php
@@ -190,6 +190,26 @@ class ReviewModerationServiceTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testBuildPromptPreservesAccentedCoasterNames(): void
+    {
+        $coaster = new Coaster();
+        $coaster->setName('Titánide');
+
+        $review = new RiddenCoaster();
+        $review->setCoaster($coaster);
+        $review->setValue(3.0);
+        $review->setReview('Bon manège');
+
+        $service = new ReviewModerationService($this->createMock(BedrockService::class), $this->createMock(LoggerInterface::class));
+
+        $reflection = new \ReflectionClass($service);
+        $buildPrompt = $reflection->getMethod('buildPrompt');
+        $prompt = $buildPrompt->invoke($service, $review);
+
+        $this->assertStringContainsString('Titánide', $prompt);
+        $this->assertStringNotContainsString('Titnide', $prompt);
+    }
+
     public function testAnalyzeAcceptsNotRiddenCategory(): void
     {
         $bedrockService = $this->createMock(BedrockService::class);


### PR DESCRIPTION
## Summary
Reviewed 32 recently-resolved AI moderation reports (16 no_action, 2 review_deleted, 13 review_text_cleared) against real human moderator decisions and found the model contradicting its own prompt rules:

- `troll`: flagged its own "life is short, let's not make it shorter" example as troll instead of `ok`.
- `not_ridden`: inferred from brevity/appearance-only comments despite the "only when stated directly" rule (e.g. "Bon prototype").
- `toxic`: flagged terse, non-profane, non-personal negative opinions ("Horrendous") as toxic.
- `offtopic`: flagged a restraint-bruising complaint as an offtopic safety report despite the "physical reactions are not offtopic" carve-out.

Reworded each rule to close the gap and re-verified against the exact false-positive examples plus a few true-positive checks, so genuinely toxic/troll/not_ridden content still gets flagged correctly.

Also fixes the same ASCII-only accent-stripping bug as the coaster summary prompt (`\w` vs `\p{L}\p{N}`).

## Test plan
- [x] `vendor/bin/phpunit` (new regression test for accented names)
- [x] `vendor/bin/phpstan analyse`
- [x] Re-ran all 4 false-positive examples live via `app:analyze-reviews --text` - all now classify `ok`
- [x] Re-ran true-positive checks (heavy profanity + insult, explicit not-ridden, boilerplate credit, toxic-toward-person) - all still correctly flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)