### PR TITLE
fix: local dev database bootstrap (composer db-setup, fixtures, integration tests)

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'
+DATABASE_URL=mysql://root:root123@127.0.0.1:3306/captain_test?serverVersion=mariadb-11.8.0&charset=utf8mb4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
 
             - name: Set up test database
               run: composer db-setup
+              env:
+                  APP_ENV: test
 
             - name: Run PHPUnit tests
               run: vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,20 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
+        services:
+            mariadb:
+                image: mariadb:11.8
+                env:
+                    MARIADB_ROOT_PASSWORD: root123
+                ports:
+                    - 3306:3306
+                options: >-
+                    --health-cmd="healthcheck.sh --connect --innodb_initialized"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=5
+        env:
+            DATABASE_URL: 'mysql://root:root123@127.0.0.1:3306/captain_test?serverVersion=mariadb-11.8.0&charset=utf8mb4'
         steps:
             - uses: actions/checkout@v7
 
@@ -36,6 +50,9 @@ jobs:
 
             - name: Install Composer dependencies
               run: composer install --no-interaction --prefer-dist --no-progress
+
+            - name: Set up test database
+              run: composer db-setup
 
             - name: Run PHPUnit tests
               run: vendor/bin/phpunit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ PHP follows the `@Symfony` + `@Symfony:risky` + `@PHP80Migration:risky` + `@PHP8
 
 ### Testing
 
-- **Unit tests only** — business logic in isolation, mocking repositories/`EntityManager`. No `KernelTestCase`/`WebTestCase` integration tests currently.
+- **Two test tiers**: unit tests (`{ClassName}Test.php`) mock repositories/`EntityManager` for isolated business logic — the default for `src/Service/`. Integration tests (`{ClassName}IntegrationTest.php`) extend `KernelTestCase` and hit a real database, seeded via Doctrine fixtures (`src/DataFixtures/`, built with `zenstruck/foundry` factories in `src/Factory/`) — used for `src/Repository/` custom-query correctness, where mocked-DQL assertions can't catch real query bugs. Each test runs inside a transaction rolled back by `dama/doctrine-test-bundle`, so fixture data loaded once (via `composer db-setup`, also what CI runs) stays intact across the whole suite.
 - **Property tests** for invariants, using Eris (`giorgiosironi/eris`) — see `tests/Service/CoasterSummaryServicePropertyTest.php` for the pattern. Keep variant counts modest; the whole suite should stay fast.
 - **Naming**: `{ClassName}Test.php` for unit tests, `{ClassName}PropertyTest.php` for property tests.
 - **Coverage expectations**: high coverage on `src/Service/` (business logic), request/response-only assertions on controllers, custom-query coverage on repositories.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,18 @@ Join us in shaping the world's best roller coaster rankings!
     - MariaDB 11.8
     - Redis
     - Adminer on localhost:8081
-7. Create a `captain` database on adminer, and import a dump file
+7. Set up the database schema and load sample data
+    ```shell
+    composer db-setup
+    ```
+    This creates the database, builds the schema from the current entity
+    mappings, marks existing migrations as applied, and loads a small set of
+    sample parks/coasters/users so the app has something to show. If you
+    have access to a production database dump, you can import that instead —
+    it already contains a full schema and doesn't need this step, though you
+    should still run `bin/console doctrine:migrations:sync-metadata-storage`
+    and `bin/console doctrine:migrations:version --add --all` afterward if
+    its migration history isn't already up to date.
 8. Start the Symfony development server
     ```shell
     symfony server:start
@@ -50,7 +61,13 @@ Join us in shaping the world's best roller coaster rankings!
     ```shell
     docker exec -ti php-captain composer install
     ```
-4. Create a `captain` database on adminer, and import a dump file
+4. Set up the database schema and load sample data
+    ```shell
+    docker exec -ti php-captain composer db-setup
+    ```
+    Same as above: builds the schema, marks existing migrations as applied,
+    and loads sample data. A production dump can be imported instead if you
+    have access to one.
 5. Browse `localhost:8080`
 
 ## Docker Compose Structure

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ Join us in shaping the world's best roller coaster rankings!
     - MariaDB 11.8
     - Redis
     - Adminer on localhost:8081
-7. Set up the database schema and load sample data
+7. Create a `.env.local` file with a working database connection
+    ```
+    DATABASE_URL=mysql://root:root123@127.0.0.1:3306/captain?serverVersion=mariadb-11.8.0&charset=utf8mb4
+    ```
+8. Set up the database schema and load sample data
     ```shell
     composer db-setup
     ```
@@ -38,11 +42,11 @@ Join us in shaping the world's best roller coaster rankings!
     should still run `bin/console doctrine:migrations:sync-metadata-storage`
     and `bin/console doctrine:migrations:version --add --all` afterward if
     its migration history isn't already up to date.
-8. Start the Symfony development server
+9. Start the Symfony development server
     ```shell
     symfony server:start
     ```
-9. Browse the application at the URL provided by Symfony CLI (typically http://localhost:8000)
+10. Browse the application at the URL provided by Symfony CLI (typically http://localhost:8000)
 
 ### Option 2: Full Docker Setup
 
@@ -61,14 +65,18 @@ Join us in shaping the world's best roller coaster rankings!
     ```shell
     docker exec -ti php-captain composer install
     ```
-4. Set up the database schema and load sample data
+4. Create a `.env.local` file with a working database connection
+    ```
+    DATABASE_URL=mysql://root:root123@db:3306/captain?serverVersion=mariadb-11.8.0&charset=utf8mb4
+    ```
+5. Set up the database schema and load sample data
     ```shell
     docker exec -ti php-captain composer db-setup
     ```
     Same as above: builds the schema, marks existing migrations as applied,
     and loads sample data. A production dump can be imported instead if you
     have access to one.
-5. Browse `localhost:8080`
+6. Browse `localhost:8080`
 
 ## Docker Compose Structure
 

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "twig/intl-extra": "^3.8"
     },
     "require-dev": {
+        "doctrine/doctrine-fixtures-bundle": "^4.3",
         "friendsofphp/php-cs-fixer": "3.95.18",
         "giorgiosironi/eris": "^1.0",
         "phpstan/extension-installer": "^1.3",
@@ -65,7 +66,8 @@
         "symfony/css-selector": "8.*",
         "symfony/debug-bundle": "8.*",
         "symfony/maker-bundle": "^1.0",
-        "symfony/web-profiler-bundle": "8.*"
+        "symfony/web-profiler-bundle": "8.*",
+        "zenstruck/foundry": "^2.12"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "twig/intl-extra": "^3.8"
     },
     "require-dev": {
+        "dama/doctrine-test-bundle": "^8.6",
         "doctrine/doctrine-fixtures-bundle": "^4.3",
         "friendsofphp/php-cs-fixer": "3.95.18",
         "giorgiosironi/eris": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,14 @@
         "post-update-cmd": [
             "@auto-scripts"
         ],
-        "phpstan": "vendor/bin/phpstan"
+        "phpstan": "vendor/bin/phpstan",
+        "db-setup": [
+            "@php bin/console doctrine:database:create --if-not-exists",
+            "@php bin/console doctrine:schema:create",
+            "@php bin/console doctrine:migrations:sync-metadata-storage",
+            "@php bin/console doctrine:migrations:version --add --all --no-interaction",
+            "@php bin/console doctrine:fixtures:load --no-interaction"
+        ]
     },
     "conflict": {
         "symfony/symfony": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "859cde95e1de459bce462dfc415b7894",
+    "content-hash": "cbd5d3243219e2c002c83dbcd43dd263",
     "packages": [
         {
             "name": "api-platform/core",
@@ -11245,6 +11245,177 @@
             "time": "2024-05-06T16:37:16+00:00"
         },
         {
+            "name": "doctrine/data-fixtures",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/data-fixtures.git",
+                "reference": "bf7ac3a050b54b261cedfb3d0a44733819062275"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/bf7ac3a050b54b261cedfb3d0a44733819062275",
+                "reference": "bf7ac3a050b54b261cedfb3d0a44733819062275",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/persistence": "^3.1 || ^4.0",
+                "php": "^8.1",
+                "psr/log": "^1.1 || ^2 || ^3"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.5 || >=5",
+                "doctrine/orm": "<2.14 || >=4",
+                "doctrine/phpcr-odm": "<1.3.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "doctrine/dbal": "^3.5 || ^4",
+                "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
+                "doctrine/orm": "^2.14 || ^3",
+                "doctrine/phpcr-odm": "^1.8 || ^2.0",
+                "ext-sqlite3": "*",
+                "fig/log-test": "^1",
+                "jackalope/jackalope-fs": "*",
+                "phpstan/phpstan": "2.1.46",
+                "phpunit/phpunit": "10.5.63 || 12.5.12",
+                "symfony/cache": "^6.4 || ^7 || ^8",
+                "symfony/var-exporter": "^6.4 || ^7 || ^8"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "For using MongoDB ODM 1.3 with PHP 7 (deprecated)",
+                "doctrine/mongodb-odm": "For loading MongoDB ODM fixtures",
+                "doctrine/orm": "For loading ORM fixtures",
+                "doctrine/phpcr-odm": "For loading PHPCR ODM fixtures"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\DataFixtures\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Data Fixtures for all Doctrine Object Managers",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "database"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/data-fixtures/issues",
+                "source": "https://github.com/doctrine/data-fixtures/tree/2.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdata-fixtures",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-01T13:56:01+00:00"
+        },
+        {
+            "name": "doctrine/doctrine-fixtures-bundle",
+            "version": "4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineFixturesBundle.git",
+                "reference": "9e013ed10d49bf7746b07204d336384a7d9b5a4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineFixturesBundle/zipball/9e013ed10d49bf7746b07204d336384a7d9b5a4d",
+                "reference": "9e013ed10d49bf7746b07204d336384a7d9b5a4d",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/data-fixtures": "^2.2",
+                "doctrine/doctrine-bundle": "^2.2 || ^3.0",
+                "doctrine/orm": "^2.14.0 || ^3.0",
+                "doctrine/persistence": "^2.4 || ^3.0 || ^4.0",
+                "php": "^8.1",
+                "psr/log": "^2 || ^3",
+                "symfony/config": "^6.4 || ^7.0 || ^8.0",
+                "symfony/console": "^6.4 || ^7.0 || ^8.0",
+                "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3",
+                "symfony/doctrine-bridge": "^6.4.16 || ^7.1.9 || ^8.0",
+                "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "< 3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "14.0.0",
+                "phpstan/phpstan": "2.1.11",
+                "phpunit/phpunit": "^10.5.38 || 11.4.14"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Bundle\\FixturesBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "https://www.doctrine-project.org"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DoctrineFixturesBundle",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "Fixture",
+                "persistence"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/DoctrineFixturesBundle/issues",
+                "source": "https://github.com/doctrine/DoctrineFixturesBundle/tree/4.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdoctrine-fixtures-bundle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-03T16:05:42+00:00"
+        },
+        {
             "name": "ergebnis/agent-detector",
             "version": "1.2.0",
             "source": {
@@ -11359,6 +11530,69 @@
                 "source": "https://github.com/igorw/evenement/tree/v3.0.2"
             },
             "time": "2023-08-08T05:53:35+00:00"
+        },
+        {
+            "name": "fakerphp/faker",
+            "version": "v1.24.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.5.26",
+                "symfony/phpunit-bridge": "^5.4.16"
+            },
+            "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
+            },
+            "time": "2024-11-21T13:46:39+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -14688,6 +14922,196 @@
                 }
             ],
             "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "zenstruck/assert",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zenstruck/assert.git",
+                "reference": "1e32d48847d4e82c345112ca226b21a1a792af0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zenstruck/assert/zipball/1e32d48847d4e82c345112ca226b21a1a792af0a",
+                "reference": "1e32d48847d4e82c345112ca226b21a1a792af0a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/polyfill-php81": "^1.23",
+                "symfony/var-exporter": "^5.4|^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.4",
+                "phpunit/phpunit": "^9.5.21",
+                "symfony/phpunit-bridge": "^6.3|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Zenstruck\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kevin Bond",
+                    "email": "kevinbond@gmail.com"
+                }
+            ],
+            "description": "Standalone, lightweight, framework agnostic, test assertion library.",
+            "homepage": "https://github.com/zenstruck/assert",
+            "keywords": [
+                "assertion",
+                "phpunit",
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/zenstruck/assert/issues",
+                "source": "https://github.com/zenstruck/assert/tree/v1.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kbond",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nikophil",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-07T01:59:12+00:00"
+        },
+        {
+            "name": "zenstruck/foundry",
+            "version": "v2.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zenstruck/foundry.git",
+                "reference": "edc85842118154bf0ae047b223427fef87a7feb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zenstruck/foundry/zipball/edc85842118154bf0ae047b223427fef87a7feb6",
+                "reference": "edc85842118154bf0ae047b223427fef87a7feb6",
+                "shasum": ""
+            },
+            "require": {
+                "fakerphp/faker": "^1.24",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.2|^3.0",
+                "symfony/polyfill-php84": "^1.32",
+                "symfony/polyfill-php85": "^1.33",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/var-exporter": "^6.4.9|~7.0.9|^7.1.2|^8.0",
+                "zenstruck/assert": "^1.4"
+            },
+            "conflict": {
+                "doctrine/cache": "<1.12.1",
+                "doctrine/persistence": "<2.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8",
+                "dama/doctrine-test-bundle": "^8.0",
+                "doctrine/collections": "^1.7|^2.0",
+                "doctrine/common": "^3.2.2",
+                "doctrine/doctrine-bundle": "^2.10|^3.0",
+                "doctrine/doctrine-migrations-bundle": "^2.2|^3.0",
+                "doctrine/mongodb-odm": "^2.4",
+                "doctrine/mongodb-odm-bundle": "^4.6|^5.0",
+                "doctrine/orm": "^2.16|^3.0",
+                "doctrine/persistence": "^2.0|^3.0|^4.0",
+                "phpunit/phpunit": "^9.5.0 || ^10.0 || ^11.0 || ^12.0 || ~13.1.0",
+                "symfony/browser-kit": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dotenv": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/flex": "^2.10",
+                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+                "symfony/maker-bundle": "^1.55",
+                "symfony/phpunit-bridge": "^6.4.26|^7.0|^8.0",
+                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/runtime": "^6.4|^7.0|^8.0",
+                "symfony/translation-contracts": "^3.4",
+                "symfony/uid": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0",
+                "webmozart/assert": "^1.11"
+            },
+            "type": "library",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Zenstruck\\Foundry\\Psalm\\FoundryPlugin"
+                },
+                "symfony": {
+                    "allow-contrib": false
+                },
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false,
+                    "target-directory": "bin/tools"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Persistence/functions.php",
+                    "src/symfony_console.php"
+                ],
+                "psr-4": {
+                    "Zenstruck\\Foundry\\": "src/",
+                    "Zenstruck\\Foundry\\Psalm\\": "utils/psalm",
+                    "Zenstruck\\Foundry\\Utils\\Rector\\": "utils/rector/src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Test/Behat/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kevin Bond",
+                    "email": "kevinbond@gmail.com"
+                },
+                {
+                    "name": "Nicolas PHILIPPE",
+                    "email": "nikophil@gmail.com"
+                }
+            ],
+            "description": "A model factory library for creating expressive, auto-completable, on-demand dev/test fixtures with Symfony and Doctrine.",
+            "homepage": "https://github.com/zenstruck/foundry",
+            "keywords": [
+                "Fixture",
+                "dev",
+                "doctrine",
+                "factory",
+                "faker",
+                "symfony",
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/zenstruck/foundry/issues",
+                "source": "https://github.com/zenstruck/foundry/tree/v2.12.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kbond",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nikophil",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-08-14T06:15:04+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cbd5d3243219e2c002c83dbcd43dd263",
+    "content-hash": "8ae84fb04d6ae7d4822f29d818796917",
     "packages": [
         {
             "name": "api-platform/core",
@@ -11243,6 +11243,75 @@
                 }
             ],
             "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "dama/doctrine-test-bundle",
+            "version": "v8.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dmaicher/doctrine-test-bundle.git",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dmaicher/doctrine-test-bundle/zipball/f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^3.3 || ^4.0",
+                "doctrine/doctrine-bundle": "^2.11.0 || ^3.0",
+                "php": ">= 8.2",
+                "psr/cache": "^2.0 || ^3.0",
+                "symfony/cache": "^6.4 || ^7.3 || ^8.0",
+                "symfony/framework-bundle": "^6.4 || ^7.3 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<11.0"
+            },
+            "require-dev": {
+                "behat/behat": "^3.0",
+                "friendsofphp/php-cs-fixer": "^3.27",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.5.41|| ^12.3.14",
+                "symfony/dotenv": "^6.4 || ^7.3 || ^8.0",
+                "symfony/process": "^6.4 || ^7.3 || ^8.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DAMA\\DoctrineTestBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Maicher",
+                    "email": "mail@dmaicher.de"
+                }
+            ],
+            "description": "Symfony bundle to isolate doctrine database tests and improve test performance",
+            "keywords": [
+                "doctrine",
+                "isolation",
+                "performance",
+                "symfony",
+                "testing",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dmaicher/doctrine-test-bundle/issues",
+                "source": "https://github.com/dmaicher/doctrine-test-bundle/tree/v8.6.0"
+            },
+            "time": "2026-01-21T07:39:44+00:00"
         },
         {
             "name": "doctrine/data-fixtures",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -25,4 +25,6 @@ return [
     Symfony\UX\Translator\UxTranslatorBundle::class => ['all' => true],
     Symfony\UX\Icons\UXIconsBundle::class => ['all' => true],
     PixelOpen\CloudflareTurnstileBundle\PixelOpenCloudflareTurnstileBundle::class => ['all' => true],
+    Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
+    Zenstruck\Foundry\ZenstruckFoundryBundle::class => ['dev' => true, 'test' => true],
 ];

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -27,4 +27,5 @@ return [
     PixelOpen\CloudflareTurnstileBundle\PixelOpenCloudflareTurnstileBundle::class => ['all' => true],
     Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
     Zenstruck\Foundry\ZenstruckFoundryBundle::class => ['dev' => true, 'test' => true],
+    DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
 ];

--- a/config/packages/dama_doctrine_test_bundle.yaml
+++ b/config/packages/dama_doctrine_test_bundle.yaml
@@ -1,0 +1,5 @@
+when@test:
+    dama_doctrine_test:
+        enable_static_connection: true
+        enable_static_meta_data_cache: true
+        enable_static_query_cache: true

--- a/config/packages/notifier.yaml
+++ b/config/packages/notifier.yaml
@@ -12,3 +12,24 @@ framework:
             high: ['chat/discord_log']
             medium: []
             low: []
+
+# Chatter listeners (e.g. ReviewReportListener) fire unconditionally on entity
+# persist. Fixtures and tests must never be able to reach real Discord
+# webhooks, even if a real DSN ends up in a local .env.local.
+when@dev:
+    framework:
+        notifier:
+            chatter_transports:
+                discord_notif: 'null://null'
+                discord_log: 'null://null'
+                discord_picture: 'null://null'
+                discord_report: 'null://null'
+
+when@test:
+    framework:
+        notifier:
+            chatter_transports:
+                discord_notif: 'null://null'
+                discord_log: 'null://null'
+                discord_picture: 'null://null'
+                discord_report: 'null://null'

--- a/config/packages/zenstruck_foundry.yaml
+++ b/config/packages/zenstruck_foundry.yaml
@@ -1,1 +1,0 @@
-zenstruck_foundry: ~

--- a/config/packages/zenstruck_foundry.yaml
+++ b/config/packages/zenstruck_foundry.yaml
@@ -1,0 +1,1 @@
+zenstruck_foundry: ~

--- a/config/reference.php
+++ b/config/reference.php
@@ -2030,6 +2030,50 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     key?: scalar|Param|null,
  *     secret?: scalar|Param|null,
  * }
+ * @psalm-type ZenstruckFoundryConfig = array{
+ *     auto_refresh_proxies?: bool|Param|null, // Deprecated: Since 2.0 auto_refresh_proxies defaults to true and this configuration has no effect. // Whether to auto-refresh proxies by default (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#auto-refresh) // Default: null
+ *     enable_auto_refresh_with_lazy_objects?: bool|Param|null, // Enable auto-refresh using PHP 8.4 lazy objects (cannot be enabled if PHP < 8.4). // Default: null
+ *     faker?: array{ // Configure the faker used by your factories.
+ *         locale?: scalar|Param|null, // The default locale to use for faker. // Default: null
+ *         seed?: scalar|Param|null, // Deprecated: The "faker.seed" configuration is deprecated and will be removed in 3.0. Use environment variable "FOUNDRY_FAKER_SEED" instead. // Random number generator seed to produce the same fake values every run. // Default: null
+ *         manage_seed?: bool|Param, // Automatically manage faker seed to ensure consistent data between test runs. // Default: true
+ *         service?: scalar|Param|null, // Service id for custom faker instance. // Default: null
+ *     },
+ *     instantiator?: array{ // Configure the default instantiator used by your object factories.
+ *         use_constructor?: bool|Param, // Use the constructor to instantiate objects. // Default: true
+ *         allow_extra_attributes?: bool|Param, // Whether or not to skip attributes that do not correspond to properties. // Default: false
+ *         always_force_properties?: bool|Param, // Whether or not to skip setters and force set object properties (public/private/protected) directly. // Default: false
+ *         service?: scalar|Param|null, // Service id of your custom instantiator. // Default: null
+ *     },
+ *     global_state?: list<scalar|Param|null>,
+ *     persistence?: array{
+ *         flush_once?: bool|Param, // Flush only once per call of `PersistentObjectFactory::create()` in userland. // Default: false
+ *     },
+ *     orm?: array{
+ *         auto_persist?: bool|Param, // Deprecated: Since 2.4 auto_persist defaults to true and this configuration has no effect. // Automatically persist entities when created. // Default: true
+ *         reset?: array{
+ *             connections?: list<scalar|Param|null>,
+ *             entity_managers?: list<scalar|Param|null>,
+ *             mode?: \Zenstruck\Foundry\ORM\ResetDatabase\ResetDatabaseMode::SCHEMA|\Zenstruck\Foundry\ORM\ResetDatabase\ResetDatabaseMode::MIGRATE|Param, // Reset mode to use with ResetDatabase trait // Default: "schema"
+ *             migrations?: array{
+ *                 configurations?: list<scalar|Param|null>,
+ *             },
+ *         },
+ *     },
+ *     mongo?: array{
+ *         auto_persist?: bool|Param, // Deprecated: Since 2.4 auto_persist defaults to true and this configuration has no effect. // Automatically persist documents when created. // Default: true
+ *         reset?: array{
+ *             document_managers?: list<scalar|Param|null>,
+ *         },
+ *     },
+ *     make_factory?: array{
+ *         default_namespace?: scalar|Param|null, // Default namespace where factories will be created by maker. // Default: "Factory"
+ *         add_hints?: bool|Param, // Add "beginner" hints in the created factory. // Default: true
+ *     },
+ *     make_story?: array{
+ *         default_namespace?: scalar|Param|null, // Default namespace where stories will be created by maker. // Default: "Story"
+ *     },
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -2079,6 +2123,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         ux_translator?: UxTranslatorConfig,
  *         ux_icons?: UxIconsConfig,
  *         pixel_open_cloudflare_turnstile?: PixelOpenCloudflareTurnstileConfig,
+ *         zenstruck_foundry?: ZenstruckFoundryConfig,
  *     },
  *     "when@prod"?: array{
  *         imports?: ImportsConfig,
@@ -2128,6 +2173,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         ux_translator?: UxTranslatorConfig,
  *         ux_icons?: UxIconsConfig,
  *         pixel_open_cloudflare_turnstile?: PixelOpenCloudflareTurnstileConfig,
+ *         zenstruck_foundry?: ZenstruckFoundryConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,

--- a/config/reference.php
+++ b/config/reference.php
@@ -2074,6 +2074,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         default_namespace?: scalar|Param|null, // Default namespace where stories will be created by maker. // Default: "Story"
  *     },
  * }
+ * @psalm-type DamaDoctrineTestConfig = array{
+ *     enable_static_connection?: mixed, // Default: true
+ *     enable_static_meta_data_cache?: bool|Param, // Default: true
+ *     enable_static_query_cache?: bool|Param, // Default: true
+ *     connection_keys?: list<mixed>,
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -2174,6 +2180,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         ux_icons?: UxIconsConfig,
  *         pixel_open_cloudflare_turnstile?: PixelOpenCloudflareTurnstileConfig,
  *         zenstruck_foundry?: ZenstruckFoundryConfig,
+ *         dama_doctrine_test?: DamaDoctrineTestConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -40,5 +40,6 @@
     </source>
 
     <extensions>
+        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
     </extensions>
 </phpunit>

--- a/src/DataFixtures/CoasterFixtures.php
+++ b/src/DataFixtures/CoasterFixtures.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use App\Factory\CoasterFactory;
+use App\Factory\LaunchFactory;
+use App\Factory\ParkFactory;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+
+final class CoasterFixtures extends Fixture implements DependentFixtureInterface
+{
+    private const array COASTER_NAMES = [
+        'Steel Vengeance', 'Millennium Force', 'Top Thrill 2', 'Maverick', 'GateKeeper', 'Raptor',
+        'Fury 325', 'Intimidator 305', 'Twisted Colossus', 'Goliath', 'Full Throttle', 'Tatsu',
+        'X2', 'Silver Star', 'Blue Fire', 'Wodan Timburcoo', 'Voltron Nevera', 'Alpina Blitz',
+        'Nemesis', 'Wicker Man', 'Hyperia', 'Icon', 'The Smiler', 'Galactica',
+    ];
+
+    public function load(ObjectManager $manager): void
+    {
+        $names = self::COASTER_NAMES;
+        shuffle($names);
+        $parks = ParkFactory::repository()->findAll();
+
+        foreach (\array_slice($names, 0, 20) as $i => $name) {
+            $coaster = CoasterFactory::createOne([
+                'name' => $name,
+                'park' => $parks[$i % \count($parks)],
+            ]);
+
+            // ~half get 1-2 launch mechanisms; the rest stay chain-lift-only (Launch is optional).
+            if (0 === $i % 2) {
+                $coaster->addLaunch(LaunchFactory::random()->_real());
+            }
+        }
+
+        // addLaunch() mutates ManyToMany collections after createOne() already
+        // flushed; an explicit flush is needed to persist those join rows.
+        $manager->flush();
+    }
+
+    public function getDependencies(): array
+    {
+        return [TaxonomyFixtures::class, ParkFixtures::class];
+    }
+}

--- a/src/DataFixtures/ParkFixtures.php
+++ b/src/DataFixtures/ParkFixtures.php
@@ -17,9 +17,9 @@ final class ParkFixtures extends Fixture implements DependentFixtureInterface
         $france = CountryFactory::repository()->findOneBy(['name' => 'France']);
         $usa = CountryFactory::repository()->findOneBy(['name' => 'United States']);
 
-        ParkFactory::createOne(['name' => 'Europa-Park', 'country' => $france, 'enabled' => true]);
-        ParkFactory::createOne(['name' => 'Cedar Point', 'country' => $usa, 'enabled' => true]);
-        ParkFactory::createOne(['name' => 'Six Flags Magic Mountain', 'country' => $usa, 'enabled' => true]);
+        ParkFactory::createOne(['name' => 'Europa-Park', 'country' => $france, 'enabled' => true, 'latitude' => 48.266778, 'longitude' => 7.722244]);
+        ParkFactory::createOne(['name' => 'Cedar Point', 'country' => $usa, 'enabled' => true, 'latitude' => 41.482224, 'longitude' => -82.684425]);
+        ParkFactory::createOne(['name' => 'Six Flags Magic Mountain', 'country' => $usa, 'enabled' => true, 'latitude' => 34.423332, 'longitude' => -118.596664]);
     }
 
     public function getDependencies(): array

--- a/src/DataFixtures/ParkFixtures.php
+++ b/src/DataFixtures/ParkFixtures.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use App\Factory\CountryFactory;
+use App\Factory\ParkFactory;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+
+final class ParkFixtures extends Fixture implements DependentFixtureInterface
+{
+    public function load(ObjectManager $manager): void
+    {
+        $france = CountryFactory::repository()->findOneBy(['name' => 'France']);
+        $usa = CountryFactory::repository()->findOneBy(['name' => 'United States']);
+
+        ParkFactory::createOne(['name' => 'Europa-Park', 'country' => $france, 'enabled' => true]);
+        ParkFactory::createOne(['name' => 'Cedar Point', 'country' => $usa, 'enabled' => true]);
+        ParkFactory::createOne(['name' => 'Six Flags Magic Mountain', 'country' => $usa, 'enabled' => true]);
+    }
+
+    public function getDependencies(): array
+    {
+        return [TaxonomyFixtures::class];
+    }
+}

--- a/src/DataFixtures/ReviewReportFixtures.php
+++ b/src/DataFixtures/ReviewReportFixtures.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use App\Factory\ReviewReportFactory;
+use App\Factory\RiddenCoasterFactory;
+use App\Factory\UserFactory;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+
+final class ReviewReportFixtures extends Fixture implements DependentFixtureInterface
+{
+    public function load(ObjectManager $manager): void
+    {
+        $reviewed = array_values(array_filter(
+            RiddenCoasterFactory::repository()->findAll(),
+            static fn ($riddenCoaster) => null !== $riddenCoaster->getReview(),
+        ));
+        $users = UserFactory::repository()->findAll();
+
+        if ([] === $reviewed) {
+            return;
+        }
+
+        shuffle($reviewed);
+
+        foreach (\array_slice($reviewed, 0, min(10, \count($reviewed))) as $riddenCoaster) {
+            $reporters = array_values(array_filter($users, static fn ($user) => $user->getId() !== $riddenCoaster->getUser()->getId()));
+
+            ReviewReportFactory::createOne([
+                'user' => $reporters[array_rand($reporters)],
+                'review' => $riddenCoaster,
+            ]);
+        }
+    }
+
+    public function getDependencies(): array
+    {
+        return [RiddenCoasterFixtures::class];
+    }
+}

--- a/src/DataFixtures/RiddenCoasterFixtures.php
+++ b/src/DataFixtures/RiddenCoasterFixtures.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use App\Entity\Tag;
+use App\Factory\CoasterFactory;
+use App\Factory\RiddenCoasterFactory;
+use App\Factory\TagFactory;
+use App\Factory\UserFactory;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+
+final class RiddenCoasterFixtures extends Fixture implements DependentFixtureInterface
+{
+    public function load(ObjectManager $manager): void
+    {
+        $coasters = CoasterFactory::repository()->findAll();
+        $users = UserFactory::repository()->findAll();
+        $proTags = TagFactory::repository()->findBy(['type' => Tag::PRO]);
+        $conTags = TagFactory::repository()->findBy(['type' => Tag::CON]);
+
+        foreach ($users as $user) {
+            $ridden = $coasters;
+            shuffle($ridden);
+            $ridden = \array_slice($ridden, 0, random_int(8, 12));
+
+            foreach ($ridden as $coaster) {
+                $riddenCoaster = RiddenCoasterFactory::createOne([
+                    'coaster' => $coaster,
+                    'user' => $user,
+                ]);
+
+                if (null !== $riddenCoaster->getReview()) {
+                    // _real() defaults to auto-refresh: calling it a second time here
+                    // would reload from DB and silently drop the pending addPro()
+                    // mutation before it's flushed. Reuse a single reference instead.
+                    $real = $riddenCoaster->_real();
+                    $real->addPro($proTags[array_rand($proTags)]->_real());
+                    if (0 === random_int(0, 1)) {
+                        $real->addCon($conTags[array_rand($conTags)]->_real());
+                    }
+                }
+            }
+        }
+
+        // addPro()/addCon() mutate ManyToMany collections after createOne()
+        // already flushed; an explicit flush is needed to persist those join rows.
+        $manager->flush();
+    }
+
+    public function getDependencies(): array
+    {
+        return [CoasterFixtures::class, UserFixtures::class];
+    }
+}

--- a/src/DataFixtures/TaxonomyFixtures.php
+++ b/src/DataFixtures/TaxonomyFixtures.php
@@ -23,8 +23,10 @@ final class TaxonomyFixtures extends Fixture
     public function load(ObjectManager $manager): void
     {
         // Status "Operating" must be created first: id 1 is relied on elsewhere.
-        StatusFactory::createOne(['name' => 'Operating', 'type' => Status::OPERATING, 'isRateable' => true, 'order' => 1]);
-        StatusFactory::createOne(['name' => 'Closed', 'type' => Status::CLOSED_DEFINITELY, 'isRateable' => false, 'order' => 2]);
+        // name holds the machine key (matched by CoasterRepository/ParkRepository status
+        // filters and translated via the 'database' domain) - not a display string.
+        StatusFactory::createOne(['name' => Status::OPERATING, 'type' => Status::OPERATING, 'isRateable' => true, 'order' => 1]);
+        StatusFactory::createOne(['name' => Status::CLOSED_DEFINITELY, 'type' => Status::CLOSED_DEFINITELY, 'isRateable' => false, 'order' => 2]);
 
         $europe = ContinentFactory::createOne(['name' => 'Europe']);
         $northAmerica = ContinentFactory::createOne(['name' => 'North America']);

--- a/src/DataFixtures/TaxonomyFixtures.php
+++ b/src/DataFixtures/TaxonomyFixtures.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use App\Entity\Status;
+use App\Entity\Tag;
+use App\Factory\ContinentFactory;
+use App\Factory\CountryFactory;
+use App\Factory\LaunchFactory;
+use App\Factory\ManufacturerFactory;
+use App\Factory\MaterialTypeFactory;
+use App\Factory\RestraintFactory;
+use App\Factory\SeatingTypeFactory;
+use App\Factory\StatusFactory;
+use App\Factory\TagFactory;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+final class TaxonomyFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        // Status "Operating" must be created first: id 1 is relied on elsewhere.
+        StatusFactory::createOne(['name' => 'Operating', 'type' => Status::OPERATING, 'isRateable' => true, 'order' => 1]);
+        StatusFactory::createOne(['name' => 'Closed', 'type' => Status::CLOSED_DEFINITELY, 'isRateable' => false, 'order' => 2]);
+
+        $europe = ContinentFactory::createOne(['name' => 'Europe']);
+        $northAmerica = ContinentFactory::createOne(['name' => 'North America']);
+
+        CountryFactory::createOne(['name' => 'France', 'continent' => $europe]);
+        CountryFactory::createOne(['name' => 'Germany', 'continent' => $europe]);
+        CountryFactory::createOne(['name' => 'United States', 'continent' => $northAmerica]);
+
+        foreach ([
+            'Bolliger & Mabillard', 'Intamin', 'Vekoma', 'Rocky Mountain Construction',
+            'Mack Rides', 'Gerstlauer', 'Zamperla', 'S&S - Sansei Technologies',
+            'Great Coasters International', 'Premier Rides',
+        ] as $name) {
+            ManufacturerFactory::createOne(['name' => $name]);
+        }
+
+        foreach (['Steel', 'Wood', 'Hybrid'] as $name) {
+            MaterialTypeFactory::createOne(['name' => $name]);
+        }
+
+        foreach (['Sit Down', 'Inverted', 'Floorless', 'Stand Up', 'Flying', 'Wing', 'Bobsled'] as $name) {
+            SeatingTypeFactory::createOne(['name' => $name]);
+        }
+
+        foreach (['Lap Bar', 'Over-the-Shoulder Restraint', 'Lap Bar and Seatbelt', 'None'] as $name) {
+            RestraintFactory::createOne(['name' => $name]);
+        }
+
+        foreach (['Chain Lift Hill', 'LSM Launch', 'LIM Launch', 'Hydraulic Launch', 'Cable Lift', 'Tire-Drive Lift'] as $name) {
+            LaunchFactory::createOne(['name' => $name]);
+        }
+
+        foreach (['Airtime', 'Smoothness', 'Theming', 'Intensity', 'Great Views'] as $name) {
+            TagFactory::createOne(['name' => $name, 'type' => Tag::PRO]);
+        }
+
+        foreach (['Rough Ride', 'Long Queue', 'Short Ride Time', 'Uncomfortable Restraints'] as $name) {
+            TagFactory::createOne(['name' => $name, 'type' => Tag::CON]);
+        }
+    }
+}

--- a/src/DataFixtures/TopFixtures.php
+++ b/src/DataFixtures/TopFixtures.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use App\Entity\TopCoaster;
+use App\Factory\TopFactory;
+use App\Factory\UserFactory;
+use App\Repository\RiddenCoasterRepository;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+
+final class TopFixtures extends Fixture implements DependentFixtureInterface
+{
+    public function __construct(private readonly RiddenCoasterRepository $riddenCoasterRepository)
+    {
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $users = UserFactory::repository()->findAll();
+
+        foreach ($users as $user) {
+            $ridden = $this->riddenCoasterRepository->findBy(['user' => $user->_real()], ['value' => 'DESC']);
+            if ([] === $ridden) {
+                continue;
+            }
+
+            $top = TopFactory::createOne([
+                'name' => 'Top 10',
+                'user' => $user,
+                'main' => true,
+            ]);
+
+            $real = $top->_real();
+            foreach (\array_slice($ridden, 0, 10) as $position => $riddenCoaster) {
+                $topCoaster = new TopCoaster();
+                $topCoaster->setCoaster($riddenCoaster->getCoaster());
+                $topCoaster->setPosition($position + 1);
+                $real->addTopCoaster($topCoaster);
+            }
+        }
+
+        $manager->flush();
+    }
+
+    public function getDependencies(): array
+    {
+        return [RiddenCoasterFixtures::class];
+    }
+}

--- a/src/DataFixtures/UserFixtures.php
+++ b/src/DataFixtures/UserFixtures.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use App\Factory\UserFactory;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+final class UserFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        UserFactory::createMany(8);
+    }
+}

--- a/src/Entity/Continent.php
+++ b/src/Entity/Continent.php
@@ -7,6 +7,7 @@ namespace App\Entity;
 use App\Repository\ContinentRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * Continent.
@@ -24,6 +25,7 @@ class Continent implements \Stringable
     private string $name = '';
 
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 255, unique: true)]
+    #[Gedmo\Slug(fields: ['name'])]
     private string $slug = '';
 
     public function __toString(): string

--- a/src/Entity/Status.php
+++ b/src/Entity/Status.php
@@ -48,7 +48,7 @@ class Status implements \Stringable
     #[Groups(['read_status'])]
     private bool $isRateable = false;
 
-    #[ORM\Column(type: Types::INTEGER, nullable: false)]
+    #[ORM\Column(name: '`order`', type: Types::INTEGER, nullable: false)]
     private int $order;
 
     public function __construct()

--- a/src/Factory/CoasterFactory.php
+++ b/src/Factory/CoasterFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use App\Entity\Coaster;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/** @extends PersistentProxyObjectFactory<Coaster> */
+final class CoasterFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return Coaster::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'name' => self::faker()->unique()->word(),
+            'park' => ParkFactory::random(),
+            'materialType' => MaterialTypeFactory::random(),
+            'seatingType' => SeatingTypeFactory::random(),
+            'manufacturer' => ManufacturerFactory::random(),
+            'restraint' => RestraintFactory::random(),
+            'status' => StatusFactory::repository()->findOneBy(['name' => 'Operating']),
+            'openingDate' => self::faker()->dateTimeBetween('-40 years', '-1 year'),
+            'height' => self::faker()->numberBetween(20, 140),
+            'speed' => self::faker()->numberBetween(40, 150),
+            'length' => self::faker()->numberBetween(500, 2000),
+            'inversionsNumber' => self::faker()->numberBetween(0, 4),
+            'enabled' => true,
+        ];
+    }
+}

--- a/src/Factory/CoasterFactory.php
+++ b/src/Factory/CoasterFactory.php
@@ -7,7 +7,9 @@ namespace App\Factory;
 use App\Entity\Coaster;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 
-/** @extends PersistentProxyObjectFactory<Coaster> */
+/**
+ * @extends PersistentProxyObjectFactory<Coaster>
+ */
 final class CoasterFactory extends PersistentProxyObjectFactory
 {
     public static function class(): string

--- a/src/Factory/CoasterFactory.php
+++ b/src/Factory/CoasterFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Factory;
 
 use App\Entity\Coaster;
+use App\Entity\Status;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 
 /**
@@ -26,7 +27,7 @@ final class CoasterFactory extends PersistentProxyObjectFactory
             'seatingType' => SeatingTypeFactory::random(),
             'manufacturer' => ManufacturerFactory::random(),
             'restraint' => RestraintFactory::random(),
-            'status' => StatusFactory::repository()->findOneBy(['name' => 'Operating']),
+            'status' => StatusFactory::repository()->findOneBy(['name' => Status::OPERATING]),
             'openingDate' => self::faker()->dateTimeBetween('-40 years', '-1 year'),
             'height' => self::faker()->numberBetween(20, 140),
             'speed' => self::faker()->numberBetween(40, 150),

--- a/src/Factory/ContinentFactory.php
+++ b/src/Factory/ContinentFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use App\Entity\Continent;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/**
+ * @extends PersistentProxyObjectFactory<Continent>
+ */
+final class ContinentFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return Continent::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'name' => self::faker()->randomElement(['Europe', 'North America']),
+        ];
+    }
+}

--- a/src/Factory/CountryFactory.php
+++ b/src/Factory/CountryFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use App\Entity\Country;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/**
+ * @extends PersistentProxyObjectFactory<Country>
+ */
+final class CountryFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return Country::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'name' => self::faker()->randomElement(['France', 'Germany', 'United States']),
+            'continent' => ContinentFactory::random(),
+        ];
+    }
+}

--- a/src/Factory/LaunchFactory.php
+++ b/src/Factory/LaunchFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use App\Entity\Launch;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/**
+ * @extends PersistentProxyObjectFactory<Launch>
+ */
+final class LaunchFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return Launch::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'name' => self::faker()->randomElement([
+                'Chain Lift Hill', 'LSM Launch', 'LIM Launch', 'Hydraulic Launch', 'Cable Lift', 'Tire-Drive Lift',
+            ]),
+        ];
+    }
+}

--- a/src/Factory/ManufacturerFactory.php
+++ b/src/Factory/ManufacturerFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use App\Entity\Manufacturer;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/**
+ * @extends PersistentProxyObjectFactory<Manufacturer>
+ */
+final class ManufacturerFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return Manufacturer::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'name' => self::faker()->randomElement([
+                'Bolliger & Mabillard',
+                'Intamin',
+                'Vekoma',
+                'Rocky Mountain Construction',
+                'Mack Rides',
+                'Gerstlauer',
+                'Zamperla',
+                'S&S - Sansei Technologies',
+                'Great Coasters International',
+                'Premier Rides',
+            ]),
+        ];
+    }
+}

--- a/src/Factory/MaterialTypeFactory.php
+++ b/src/Factory/MaterialTypeFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use App\Entity\MaterialType;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/**
+ * @extends PersistentProxyObjectFactory<MaterialType>
+ */
+final class MaterialTypeFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return MaterialType::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'name' => self::faker()->randomElement(['Steel', 'Wood', 'Hybrid']),
+        ];
+    }
+}

--- a/src/Factory/ParkFactory.php
+++ b/src/Factory/ParkFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use App\Entity\Park;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/** @extends PersistentProxyObjectFactory<Park> */
+final class ParkFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return Park::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'name' => self::faker()->randomElement(['Europa-Park', 'Cedar Point', 'Six Flags Magic Mountain']),
+            'country' => CountryFactory::random(),
+            'enabled' => true,
+        ];
+    }
+}

--- a/src/Factory/ParkFactory.php
+++ b/src/Factory/ParkFactory.php
@@ -7,7 +7,9 @@ namespace App\Factory;
 use App\Entity\Park;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 
-/** @extends PersistentProxyObjectFactory<Park> */
+/**
+ * @extends PersistentProxyObjectFactory<Park>
+ */
 final class ParkFactory extends PersistentProxyObjectFactory
 {
     public static function class(): string

--- a/src/Factory/RestraintFactory.php
+++ b/src/Factory/RestraintFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use App\Entity\Restraint;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/**
+ * @extends PersistentProxyObjectFactory<Restraint>
+ */
+final class RestraintFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return Restraint::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'name' => self::faker()->randomElement([
+                'Lap Bar', 'Over-the-Shoulder Restraint', 'Lap Bar and Seatbelt', 'None',
+            ]),
+        ];
+    }
+}

--- a/src/Factory/ReviewReportFactory.php
+++ b/src/Factory/ReviewReportFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use App\Entity\ReviewReport;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/**
+ * @extends PersistentProxyObjectFactory<ReviewReport>
+ */
+final class ReviewReportFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return ReviewReport::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'user' => UserFactory::random(),
+            'reason' => self::faker()->randomElement(ReviewReport::REASONS),
+        ];
+    }
+}

--- a/src/Factory/RiddenCoasterFactory.php
+++ b/src/Factory/RiddenCoasterFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use App\Entity\RiddenCoaster;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/** @extends PersistentProxyObjectFactory<RiddenCoaster> */
+final class RiddenCoasterFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return RiddenCoaster::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'coaster' => CoasterFactory::random(),
+            'user' => UserFactory::random(),
+            'value' => self::faker()->randomElement([0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0]),
+            'review' => self::faker()->boolean(70) ? self::faker()->realText(200) : null,
+            'language' => 'en',
+            'riddenAt' => self::faker()->dateTimeBetween('-5 years', 'now'),
+        ];
+    }
+}

--- a/src/Factory/RiddenCoasterFactory.php
+++ b/src/Factory/RiddenCoasterFactory.php
@@ -7,7 +7,9 @@ namespace App\Factory;
 use App\Entity\RiddenCoaster;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 
-/** @extends PersistentProxyObjectFactory<RiddenCoaster> */
+/**
+ * @extends PersistentProxyObjectFactory<RiddenCoaster>
+ */
 final class RiddenCoasterFactory extends PersistentProxyObjectFactory
 {
     public static function class(): string

--- a/src/Factory/SeatingTypeFactory.php
+++ b/src/Factory/SeatingTypeFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use App\Entity\SeatingType;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/**
+ * @extends PersistentProxyObjectFactory<SeatingType>
+ */
+final class SeatingTypeFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return SeatingType::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'name' => self::faker()->randomElement([
+                'Sit Down', 'Inverted', 'Floorless', 'Stand Up', 'Flying', 'Wing', 'Bobsled',
+            ]),
+        ];
+    }
+}

--- a/src/Factory/StatusFactory.php
+++ b/src/Factory/StatusFactory.php
@@ -20,7 +20,7 @@ final class StatusFactory extends PersistentProxyObjectFactory
     protected function defaults(): array
     {
         return [
-            'name' => 'Operating',
+            'name' => Status::OPERATING,
             'type' => Status::OPERATING,
             'isRateable' => true,
             'order' => 1,

--- a/src/Factory/StatusFactory.php
+++ b/src/Factory/StatusFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use App\Entity\Status;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/**
+ * @extends PersistentProxyObjectFactory<Status>
+ */
+final class StatusFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return Status::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'name' => 'Operating',
+            'type' => Status::OPERATING,
+            'isRateable' => true,
+            'order' => 1,
+        ];
+    }
+}

--- a/src/Factory/TagFactory.php
+++ b/src/Factory/TagFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use App\Entity\Tag;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/**
+ * @extends PersistentProxyObjectFactory<Tag>
+ */
+final class TagFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return Tag::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'name' => self::faker()->word(),
+            'type' => Tag::PRO,
+        ];
+    }
+}

--- a/src/Factory/TopFactory.php
+++ b/src/Factory/TopFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use App\Entity\Top;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/**
+ * @extends PersistentProxyObjectFactory<Top>
+ */
+final class TopFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return Top::class;
+    }
+
+    protected function defaults(): array
+    {
+        return [
+            'name' => self::faker()->realText(30),
+            'user' => UserFactory::random(),
+            'main' => false,
+        ];
+    }
+}

--- a/src/Factory/UserFactory.php
+++ b/src/Factory/UserFactory.php
@@ -24,6 +24,10 @@ final class UserFactory extends PersistentProxyObjectFactory
             'firstName' => $firstName,
             'displayName' => $firstName.' '.self::faker()->lastName(),
             'preferredLocale' => 'en',
+            // User::$enabled defaults to false; without this, UserChecker rejects
+            // every fixture user as banned, and review listings (which filter on
+            // u.enabled = 1) show no reviews at all.
+            'enabled' => true,
         ];
     }
 }

--- a/src/Factory/UserFactory.php
+++ b/src/Factory/UserFactory.php
@@ -7,7 +7,9 @@ namespace App\Factory;
 use App\Entity\User;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 
-/** @extends PersistentProxyObjectFactory<User> */
+/**
+ * @extends PersistentProxyObjectFactory<User>
+ */
 final class UserFactory extends PersistentProxyObjectFactory
 {
     public static function class(): string
@@ -18,11 +20,15 @@ final class UserFactory extends PersistentProxyObjectFactory
     protected function defaults(): array
     {
         $firstName = self::faker()->firstName();
+        $lastName = self::faker()->lastName();
 
         return [
             'email' => self::faker()->unique()->safeEmail(),
             'firstName' => $firstName,
-            'displayName' => $firstName.' '.self::faker()->lastName(),
+            'lastName' => $lastName,
+            // UserListener::prePersist() always overwrites this from firstName/lastName;
+            // kept as a harmless default in case that listener behavior ever changes.
+            'displayName' => $firstName.' '.$lastName,
             'preferredLocale' => 'en',
             // User::$enabled defaults to false; without this, UserChecker rejects
             // every fixture user as banned, and review listings (which filter on

--- a/src/Factory/UserFactory.php
+++ b/src/Factory/UserFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use App\Entity\User;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/** @extends PersistentProxyObjectFactory<User> */
+final class UserFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return User::class;
+    }
+
+    protected function defaults(): array
+    {
+        $firstName = self::faker()->firstName();
+
+        return [
+            'email' => self::faker()->unique()->safeEmail(),
+            'firstName' => $firstName,
+            'displayName' => $firstName.' '.self::faker()->lastName(),
+            'preferredLocale' => 'en',
+        ];
+    }
+}

--- a/src/Repository/ImageRepository.php
+++ b/src/Repository/ImageRepository.php
@@ -21,7 +21,7 @@ class ImageRepository extends ServiceEntityRepository
         parent::__construct($registry, Image::class);
     }
 
-    public function findLatestLikedImage(): Image
+    public function findLatestLikedImage(): ?Image
     {
         $query = $this->createQueryBuilder('i')
             ->join(LikedImage::class, 'li', 'WITH', 'li.image = i.id')
@@ -33,7 +33,7 @@ class ImageRepository extends ServiceEntityRepository
 
         $query->enableResultCache(300);
 
-        return $query->getSingleResult();
+        return $query->getOneOrNullResult();
     }
 
     /** @return Query<mixed, mixed> */

--- a/symfony.lock
+++ b/symfony.lock
@@ -13,6 +13,18 @@
             "src/ApiResource/.gitignore"
         ]
     },
+    "dama/doctrine-test-bundle": {
+        "version": "8.6",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "8.3",
+            "ref": "dfc51177476fb39d014ed89944cde53dc3326d23"
+        },
+        "files": [
+            "config/packages/dama_doctrine_test_bundle.yaml"
+        ]
+    },
     "doctrine/annotations": {
         "version": "2.0",
         "recipe": {

--- a/templates/Default/index.html.twig
+++ b/templates/Default/index.html.twig
@@ -70,6 +70,7 @@
   <div class="row">
     <div class="col-sm-6">
       <!-- Thumbnail with image and button -->
+      {% if image %}
       <div class="thumbnail">
           <a href="{{ path('show_coaster', {'id': image.coaster.id, 'slug': image.coaster.slug}) }}">
           <div class="thumb">
@@ -89,6 +90,7 @@
           <p class="text-muted mb-15 mt-5">{{ 'image.credit'|trans({'%name%': image.credit}) }}</p>
         </div>
       </div>
+      {% endif %}
       <!-- /thumbnail with image and button -->
       <!-- latest ratings -->
       <div class="panel panel-flat border-top-teal">

--- a/templates/ranking/info.html.twig
+++ b/templates/ranking/info.html.twig
@@ -1,4 +1,5 @@
 <div class="panel panel-flat">
+  {% if ranking %}
   <div class="panel-heading has-visible-elements">
     <h6 class="panel-title">{{ 'coaster_ranking.info.title'|trans({'%rankingMonth%': ranking.computedAt|format_datetime('long', 'none')}) }}</h6>
     <div class="heading-elements visible-elements" style="display: flex; gap: 1rem; flex-wrap: wrap;">
@@ -20,7 +21,7 @@
       <div class="content-group">
         <h6 class="text-semibold no-margin">
           {{ ux_icon('heroicons:chat-bubble-left', {'class': 'w-6 h-6 position-left text-slate'}) }}<br/>{{ ranking.rankedCoasterNumber }}&nbsp;
-          {% if ranking.rankedCoasterNumber - previousRanking.rankedCoasterNumber > 0 %}
+          {% if previousRanking and ranking.rankedCoasterNumber - previousRanking.rankedCoasterNumber > 0 %}
             <span class="badge bg-blue-400">+{{ ranking.rankedCoasterNumber - previousRanking.rankedCoasterNumber }}</span>
           {% endif %}
         </h6>
@@ -32,7 +33,7 @@
       <div class="content-group">
         <h6 class="text-semibold no-margin">
           {{ ux_icon('heroicons:star', {'class': 'w-6 h-6 position-left text-slate'}) }}<br/>{{ ranking.ratingNumber|shortNum }}&nbsp;
-          {% if ranking.ratingNumber - previousRanking.ratingNumber > 1000 %}
+          {% if previousRanking and ranking.ratingNumber - previousRanking.ratingNumber > 1000 %}
             <span class="badge bg-blue-400">+{{ (ranking.ratingNumber - previousRanking.ratingNumber)|shortNum }}</span>
           {% endif %}
         </h6>
@@ -43,7 +44,7 @@
       <div class="content-group">
         <h6 class="text-semibold no-margin">
           {{ ux_icon('heroicons:user-group', {'class': 'w-6 h-6 position-left text-slate'}) }}<br/>{{ ranking.userNumber }}&nbsp;
-          {% if ranking.userNumber - previousRanking.userNumber > 0 %}
+          {% if previousRanking and ranking.userNumber - previousRanking.userNumber > 0 %}
             <span class="badge bg-blue-400">+{{ ranking.userNumber - previousRanking.userNumber }}</span>
           {% endif %}
         </h6>
@@ -54,7 +55,7 @@
       <div class="content-group">
         <h6 class="text-semibold no-margin">
           {{ ux_icon('heroicons:arrows-right-left', {'class': 'w-6 h-6 position-left text-slate'}) }}<br/>{{ ranking.comparisonNumber|shortNum }}&nbsp;
-          {% if ranking.comparisonNumber - previousRanking.comparisonNumber > 1000 %}
+          {% if previousRanking and ranking.comparisonNumber - previousRanking.comparisonNumber > 1000 %}
             <span class="badge bg-blue-400">+{{ (ranking.comparisonNumber - previousRanking.comparisonNumber)|shortNum }}</span>
           {% endif %}
         </h6>
@@ -63,4 +64,10 @@
       </div>
     </div>
   </div>
+  {% else %}
+  <div class="panel-body text-center text-muted">
+    {{ ux_icon('heroicons:chart-bar', {'class': 'w-8 h-8 position-left text-slate'}) }}
+    {{ 'coaster_ranking.info.not_computed'|trans }}
+  </div>
+  {% endif %}
 </div>

--- a/tests/Repository/RepositoryIntegrationTestCase.php
+++ b/tests/Repository/RepositoryIntegrationTestCase.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+abstract class RepositoryIntegrationTestCase extends KernelTestCase
+{
+    protected EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        if (!$entityManager instanceof EntityManagerInterface) {
+            throw new \RuntimeException('Expected EntityManagerInterface from the container.');
+        }
+
+        $this->entityManager = $entityManager;
+    }
+}

--- a/tests/Repository/RiddenCoasterModerationQueryIntegrationTest.php
+++ b/tests/Repository/RiddenCoasterModerationQueryIntegrationTest.php
@@ -33,7 +33,9 @@ final class RiddenCoasterModerationQueryIntegrationTest extends RepositoryIntegr
         /** @var RiddenCoasterRepository $repository */
         $repository = $this->entityManager->getRepository(\App\Entity\RiddenCoaster::class);
 
-        $result = $repository->findPendingAnalysis(null, 100);
+        // Limit set well above any realistic base-fixture volume so this test's own
+        // rows (created last, highest ids) are never pushed out of the id-ordered window.
+        $result = $repository->findPendingAnalysis(null, 10000);
         $resultIds = array_map(static fn ($r) => $r->getId(), $result);
 
         $this->assertContains($pending->getId(), $resultIds);

--- a/tests/Repository/RiddenCoasterModerationQueryIntegrationTest.php
+++ b/tests/Repository/RiddenCoasterModerationQueryIntegrationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Repository;
+
+use App\Factory\CoasterFactory;
+use App\Factory\RiddenCoasterFactory;
+use App\Factory\UserFactory;
+use App\Repository\RiddenCoasterRepository;
+
+final class RiddenCoasterModerationQueryIntegrationTest extends RepositoryIntegrationTestCase
+{
+    public function testFindPendingAnalysisReturnsOnlyUnmoderatedReviews(): void
+    {
+        $coaster = CoasterFactory::createOne();
+        $user = UserFactory::createOne();
+
+        $pending = RiddenCoasterFactory::createOne([
+            'coaster' => $coaster,
+            'user' => $user,
+            'review' => 'A genuinely thrilling ride with strong airtime.',
+            'moderatedAt' => null,
+        ]);
+
+        $alreadyModerated = RiddenCoasterFactory::createOne([
+            'coaster' => CoasterFactory::createOne(),
+            'user' => $user,
+            'review' => 'Already reviewed by moderation.',
+            'moderatedAt' => new \DateTime(),
+        ]);
+
+        /** @var RiddenCoasterRepository $repository */
+        $repository = $this->entityManager->getRepository(\App\Entity\RiddenCoaster::class);
+
+        $result = $repository->findPendingAnalysis(null, 100);
+        $resultIds = array_map(static fn ($r) => $r->getId(), $result);
+
+        $this->assertContains($pending->getId(), $resultIds);
+        $this->assertNotContains($alreadyModerated->getId(), $resultIds);
+    }
+}

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -132,6 +132,7 @@ coaster_ranking:
         title: 'Letzte Aktualisierung: {rankingMonth}'
         next: 'Nächste Aktualisierung {date}'
         learn_more: Erfahre mehr über das Ranking
+        not_computed: 'Das Ranking wurde noch nicht berechnet. Schau nach der nächsten monatlichen Aktualisierung wieder vorbei.'
         coasters_ranked:
             short: Achterbahnen
             long: Eingestufte Achterbahnen

--- a/translations/messages+intl-icu.en.yml
+++ b/translations/messages+intl-icu.en.yml
@@ -127,6 +127,7 @@ coaster_ranking:
         title: 'Last Updated: {rankingMonth}'
         next: 'Next update {date}'
         learn_more: 'Learn more about the ranking'
+        not_computed: "The ranking hasn't been computed yet. Check back after the next monthly update."
         coasters_ranked:
             short: 'coasters'
             long: 'ranked coasters'

--- a/translations/messages+intl-icu.es.yml
+++ b/translations/messages+intl-icu.es.yml
@@ -132,6 +132,7 @@ coaster_ranking:
         title: 'Última actualización: {rankingMonth}'
         next: 'Próxima actualización {date}'
         learn_more: Más información sobre la clasificación
+        not_computed: 'La clasificación aún no se ha calculado. Vuelve después de la próxima actualización mensual.'
         coasters_ranked:
             short: montañas rusas
             long: montañas rusas clasificados

--- a/translations/messages+intl-icu.fr.yml
+++ b/translations/messages+intl-icu.fr.yml
@@ -132,6 +132,7 @@ coaster_ranking:
         title: 'Mis à jour : {rankingMonth}'
         next: 'Prochaine mise à jour {date}'
         learn_more: En apprendre plus sur le classement
+        not_computed: "Le classement n'a pas encore été calculé. Revenez après la prochaine mise à jour mensuelle."
         coasters_ranked:
             short: coasters
             long: coasters classés


### PR DESCRIPTION
## Summary

Closes #318. The README pointed contributors at a database dump that doesn't exist, and Doctrine migrations don't run against an empty database (the earliest tracked migration assumes a pre-existing schema, predating migration tracking).

- `composer db-setup` builds the schema from current entity mappings and marks the 35 pre-existing migrations as already-applied bookkeeping (Doctrine's documented pattern for adopting migrations after schema/data already existed) — no production migration state touched.
- Doctrine fixtures (via `doctrine/doctrine-fixtures-bundle` + `zenstruck/foundry` factories) seed a small, realistic dataset: real public taxonomy/manufacturer/coaster/park names, synthetic users and reviews.
- CI now runs against a real MariaDB service using the same `composer db-setup` script.
- Added `dama/doctrine-test-bundle` and the project's first `KernelTestCase` integration test (`RiddenCoasterRepository::findPendingAnalysis`), closing a real gap: the existing mocked test could only assert on generated DQL strings, not real query correctness.
- README and `CLAUDE.md` updated accordingly.

## Test plan
- [x] `composer db-setup` runs end-to-end against a clean database
- [x] `bin/console make:migration` reports no schema drift after bootstrap
- [x] `vendor/bin/phpunit` — 167 tests passing
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `vendor/bin/php-cs-fixer fix --dry-run` — clean
- [x] `bin/console lint:twig templates --env=prod` — clean (prod kernel boots)
- [x] Manually browsed seeded coaster/park pages and reviews on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)