### PR TITLE
fix: slug generation for remaining taxonomy entities

### DIFF
--- a/src/Entity/Continent.php
+++ b/src/Entity/Continent.php
@@ -7,6 +7,7 @@ namespace App\Entity;
 use App\Repository\ContinentRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * Continent.
@@ -24,7 +25,8 @@ class Continent implements \Stringable
     private string $name = '';
 
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 255, unique: true)]
-    private string $slug = '';
+    #[Gedmo\Slug(fields: ['name'])]
+    private ?string $slug = null;
 
     public function __toString(): string
     {
@@ -48,12 +50,12 @@ class Continent implements \Stringable
         return $this;
     }
 
-    public function getSlug(): string
+    public function getSlug(): ?string
     {
         return $this->slug;
     }
 
-    public function setSlug(string $slug): self
+    public function setSlug(?string $slug): self
     {
         $this->slug = $slug;
 

--- a/src/Entity/Country.php
+++ b/src/Entity/Country.php
@@ -28,7 +28,7 @@ class Country implements \Stringable
 
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 255, unique: true)]
     #[Gedmo\Slug(fields: ['name'])]
-    private string $slug = '';
+    private ?string $slug = null;
 
     #[ORM\ManyToOne(targetEntity: Continent::class)]
     #[ORM\JoinColumn]
@@ -76,7 +76,7 @@ class Country implements \Stringable
     /**
      * Set slug.
      *
-     * @param string $slug
+     * @param string|null $slug
      *
      * @return Country
      */
@@ -90,7 +90,7 @@ class Country implements \Stringable
     /**
      * Get slug.
      *
-     * @return string
+     * @return string|null
      */
     public function getSlug()
     {

--- a/src/Entity/Launch.php
+++ b/src/Entity/Launch.php
@@ -31,7 +31,7 @@ class Launch implements \Stringable
 
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 255, unique: true)]
     #[Gedmo\Slug(fields: ['name'])]
-    private string $slug = '';
+    private ?string $slug = null;
 
     /** @var Collection<int, Coaster> */
     #[ORM\ManyToMany(targetEntity: Coaster::class, mappedBy: 'launchs')]
@@ -64,14 +64,14 @@ class Launch implements \Stringable
         return $this->name;
     }
 
-    public function setSlug(string $slug): static
+    public function setSlug(?string $slug): static
     {
         $this->slug = $slug;
 
         return $this;
     }
 
-    public function getSlug(): string
+    public function getSlug(): ?string
     {
         return $this->slug;
     }

--- a/src/Entity/Manufacturer.php
+++ b/src/Entity/Manufacturer.php
@@ -28,7 +28,7 @@ class Manufacturer implements \Stringable
 
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 255, unique: true)]
     #[Gedmo\Slug(fields: ['name'])]
-    private string $slug = '';
+    private ?string $slug = null;
 
     public function __toString(): string
     {
@@ -72,7 +72,7 @@ class Manufacturer implements \Stringable
     /**
      * Get slug.
      *
-     * @return string
+     * @return string|null
      */
     public function getSlug()
     {
@@ -82,7 +82,7 @@ class Manufacturer implements \Stringable
     /**
      * Set slug.
      *
-     * @param string $slug
+     * @param string|null $slug
      *
      * @return Manufacturer
      */

--- a/src/Entity/MaterialType.php
+++ b/src/Entity/MaterialType.php
@@ -28,7 +28,7 @@ class MaterialType implements \Stringable
 
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 255, unique: true)]
     #[Gedmo\Slug(fields: ['name'])]
-    private string $slug = '';
+    private ?string $slug = null;
 
     public function __toString(): string
     {
@@ -72,7 +72,7 @@ class MaterialType implements \Stringable
     /**
      * Get slug.
      *
-     * @return string
+     * @return string|null
      */
     public function getSlug()
     {
@@ -82,7 +82,7 @@ class MaterialType implements \Stringable
     /**
      * Set slug.
      *
-     * @param string $slug
+     * @param string|null $slug
      *
      * @return MaterialType
      */

--- a/src/Entity/Model.php
+++ b/src/Entity/Model.php
@@ -30,7 +30,7 @@ class Model implements \Stringable
     private string $name = '';
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 255, unique: true)]
     #[Gedmo\Slug(fields: ['name'])]
-    private string $slug = '';
+    private ?string $slug = null;
 
     public function __toString(): string
     {
@@ -74,7 +74,7 @@ class Model implements \Stringable
     /**
      * Set slug.
      *
-     * @param string $slug
+     * @param string|null $slug
      *
      * @return Model
      */
@@ -88,7 +88,7 @@ class Model implements \Stringable
     /**
      * Get slug.
      *
-     * @return string
+     * @return string|null
      */
     public function getSlug()
     {

--- a/src/Entity/Restraint.php
+++ b/src/Entity/Restraint.php
@@ -32,7 +32,7 @@ class Restraint implements \Stringable
     private string $name = '';
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 255, unique: true)]
     #[Gedmo\Slug(fields: ['name'])]
-    private string $slug = '';
+    private ?string $slug = null;
     /** @var Collection<int, Coaster> */
     #[ORM\OneToMany(targetEntity: Coaster::class, mappedBy: 'restraint')]
     private Collection $coasters;
@@ -73,7 +73,7 @@ class Restraint implements \Stringable
     }
 
     /**
-     * @param string $slug
+     * @param string|null $slug
      *
      * @return Restraint
      */
@@ -84,7 +84,7 @@ class Restraint implements \Stringable
         return $this;
     }
 
-    /** @return string */
+    /** @return string|null */
     public function getSlug()
     {
         return $this->slug;

--- a/src/Entity/SeatingType.php
+++ b/src/Entity/SeatingType.php
@@ -28,7 +28,7 @@ class SeatingType implements \Stringable
 
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 255, unique: true)]
     #[Gedmo\Slug(fields: ['name'])]
-    private string $slug = '';
+    private ?string $slug = null;
 
     public function __toString(): string
     {
@@ -72,7 +72,7 @@ class SeatingType implements \Stringable
     /**
      * Set slug.
      *
-     * @param string $slug
+     * @param string|null $slug
      *
      * @return SeatingType
      */
@@ -86,7 +86,7 @@ class SeatingType implements \Stringable
     /**
      * Get slug.
      *
-     * @return string
+     * @return string|null
      */
     public function getSlug()
     {

--- a/src/Entity/Status.php
+++ b/src/Entity/Status.php
@@ -35,7 +35,7 @@ class Status implements \Stringable
 
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 255, unique: true)]
     #[Gedmo\Slug(fields: ['name'])]
-    private string $slug = '';
+    private ?string $slug = null;
 
     #[ORM\Column(name: 'type', type: Types::STRING, length: 255)]
     private string $type = '';
@@ -78,14 +78,14 @@ class Status implements \Stringable
         return $this->name;
     }
 
-    public function setSlug(string $slug): static
+    public function setSlug(?string $slug): static
     {
         $this->slug = $slug;
 
         return $this;
     }
 
-    public function getSlug(): string
+    public function getSlug(): ?string
     {
         return $this->slug;
     }


### PR DESCRIPTION
## Summary

Closes #304. #305 fixed slug generation for `Coaster` by switching `private string $slug = '';` to `private ?string $slug = null;` — Gedmo's `SluggableListener` only regenerates a slug when the field is `null`; a non-null empty-string default made it treat the slug as already set, so it persisted `''` (then `-1`, `-2`... via the uniqueness suffix) instead of a real slug on create.

The same bug was still present in 9 other entities that never got this fix: `Continent`, `Country`, `Manufacturer`, `MaterialType`, `SeatingType`, `Restraint`, `Launch`, `Model`, `Status`. This applies the identical fix to all of them.

`Continent` had an additional, separate gap: it was missing the `#[Gedmo\Slug]` attribute entirely (present on every sibling entity), so its slug was never generated at all, not even the broken `''`/`-N` pattern.

No application code calls `getSlug()` on any of these 9 entities outside their own class definitions, so the nullable return type change has no callers to update.

## Test plan
- [x] Verified against a live database: all 9 entities now generate correct slugs on create (e.g. "Bolliger & Mabillard" → "bolliger-mabillard", "Europe" → "europe")
- [x] `vendor/bin/phpunit` — 166 tests passing
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `vendor/bin/php-cs-fixer fix --dry-run` — clean
- [x] `bin/console doctrine:schema:validate --skip-sync` — mapping correct
- [x] `bin/console lint:twig templates --env=prod` — clean (prod kernel boots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)