### PR TITLE
fix: Operating World Top 100 counter unreachable due to closed coasters

### DIFF
--- a/src/Repository/RiddenCoasterRepository.php
+++ b/src/Repository/RiddenCoasterRepository.php
@@ -6,6 +6,7 @@ namespace App\Repository;
 
 use App\Entity\Coaster;
 use App\Entity\RiddenCoaster;
+use App\Entity\Status;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\NonUniqueResultException;
@@ -455,22 +456,48 @@ class RiddenCoasterRepository extends ServiceEntityRepository
     /**
      * Count ridden coasters for a user in Top 100.
      *
+     * nb_top100 counts ridden coasters within the overall Top 100 (closed/destroyed
+     * coasters included, since they still hold their all-time rank). nb_top100_operating
+     * counts ridden coasters within the top 100 *still-operating* coasters — a separate
+     * ranking with closed ones excluded entirely, not just the operating subset of the
+     * overall Top 100. Otherwise closed coasters occupying overall-Top-100 slots would
+     * make 100/100 operating permanently unreachable.
+     *
      * @return array{nb_top100: int, nb_top100_operating: int}|int
      */
     public function countTop100ForUser(User $user): array|int
     {
+        $operatingTop100Ids = $this->getEntityManager()
+            ->createQueryBuilder()
+            ->select('c.id')
+            ->from(Coaster::class, 'c')
+            ->join('c.status', 's')
+            ->where('s.name = :operating')
+            ->andWhere('c.rank IS NOT NULL')
+            ->orderBy('c.rank', 'ASC')
+            ->setMaxResults(100)
+            ->setParameter('operating', Status::OPERATING)
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        // Guard against an empty IN(), which Doctrine can't compile.
+        if ([] === $operatingTop100Ids) {
+            $operatingTop100Ids = [0];
+        }
+
         try {
             return $this->getEntityManager()
                 ->createQueryBuilder()
                 ->select([
-                    'COUNT(1) as nb_top100',
-                    'SUM(CASE WHEN c.status = 1 THEN 1 ELSE 0 END) AS nb_top100_operating',
+                    'SUM(CASE WHEN c.rank <= 100 THEN 1 ELSE 0 END) as nb_top100',
+                    'SUM(CASE WHEN c.id IN (:operatingTop100Ids) THEN 1 ELSE 0 END) AS nb_top100_operating',
                 ])
                 ->from(RiddenCoaster::class, 'r')
                 ->join('r.coaster', 'c')
                 ->where('r.user = :user')
-                ->andWhere('c.rank <= 100')
+                ->andWhere('c.rank <= 100 OR c.id IN (:operatingTop100Ids)')
                 ->setParameter('user', $user)
+                ->setParameter('operatingTop100Ids', $operatingTop100Ids)
                 ->getQuery()
                 ->getSingleResult();
         } catch (NonUniqueResultException) {

--- a/tests/Repository/RiddenCoasterRepositoryTest.php
+++ b/tests/Repository/RiddenCoasterRepositoryTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Repository;
+
+use App\Entity\User;
+use App\Repository\RiddenCoasterRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for RiddenCoasterRepository::countTop100ForUser().
+ *
+ * Uses real QueryBuilder instances (built against a mocked EntityManager) so the
+ * generated DQL is genuine, only the final Query execution is stubbed — this
+ * catches DQL-building regressions (e.g. a hardcoded Status id creeping back in)
+ * that a fully-mocked QueryBuilder would miss.
+ */
+class RiddenCoasterRepositoryTest extends TestCase
+{
+    private EntityManagerInterface&MockObject $em;
+    private RiddenCoasterRepository&MockObject $repository;
+
+    /** @var list<string> */
+    private array $capturedDql = [];
+
+    protected function setUp(): void
+    {
+        $this->capturedDql = [];
+
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->em->method('createQueryBuilder')->willReturnCallback(
+            fn () => new QueryBuilder($this->em)
+        );
+
+        $this->repository = $this->getMockBuilder(RiddenCoasterRepository::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getEntityManager'])
+            ->getMock();
+        $this->repository->method('getEntityManager')->willReturn($this->em);
+    }
+
+    /**
+     * @param array<int>                                      $operatingTop100Ids result of the first (ids) query
+     * @param array{nb_top100: int, nb_top100_operating: int} $aggregate          result of the second (counts) query
+     */
+    private function stubQueries(array $operatingTop100Ids, array $aggregate): void
+    {
+        $this->em->method('createQuery')->willReturnCallback(function (string $dql) use ($operatingTop100Ids, $aggregate) {
+            $this->capturedDql[] = $dql;
+
+            $query = $this->createMock(Query::class);
+            $query->method('setParameters')->willReturnSelf();
+            $query->method('setFirstResult')->willReturnSelf();
+            $query->method('setMaxResults')->willReturnSelf();
+
+            if (str_contains($dql, 'nb_top100_operating')) {
+                $query->method('getSingleResult')->willReturn($aggregate);
+            } else {
+                $query->method('getSingleColumnResult')->willReturn($operatingTop100Ids);
+            }
+
+            return $query;
+        });
+    }
+
+    public function testCountTop100ForUserFiltersOperatingCoastersByStatusNameNotId(): void
+    {
+        $this->stubQueries([11, 22, 33], ['nb_top100' => 5, 'nb_top100_operating' => 3]);
+
+        $this->repository->countTop100ForUser(new User());
+
+        $idsDql = $this->capturedDql[0];
+
+        // Must match the pattern used everywhere else in the codebase
+        // (CoasterRepository, ParkRepository): compare Status by name, not a
+        // hardcoded id — an id-based comparison silently breaks if ids shift.
+        $this->assertStringContainsString('s.name = :operating', $idsDql);
+        $this->assertStringNotContainsString('= 1', $idsDql);
+    }
+
+    public function testCountTop100ForUserReturnsAggregateCounts(): void
+    {
+        $this->stubQueries([11, 22, 33], ['nb_top100' => 5, 'nb_top100_operating' => 3]);
+
+        $result = $this->repository->countTop100ForUser(new User());
+
+        $this->assertSame(['nb_top100' => 5, 'nb_top100_operating' => 3], $result);
+    }
+
+    public function testCountTop100ForUserDoesNotCrashWhenNoCoasterIsOperating(): void
+    {
+        // No operating coasters at all — must not build an empty IN(), which
+        // Doctrine can't compile.
+        $this->stubQueries([], ['nb_top100' => 5, 'nb_top100_operating' => 0]);
+
+        $result = $this->repository->countTop100ForUser(new User());
+
+        $this->assertSame(['nb_top100' => 5, 'nb_top100_operating' => 0], $result);
+    }
+}


### PR DESCRIPTION
## Summary
- `countTop100ForUser` filtered the "Operating" count *within* the global Top 100 (`c.rank <= 100`), which still includes closed/destroyed coasters keeping their all-time rank. Each one occupies a slot that displaces an operating coaster, making 100/100 permanently unreachable.
- Rank operating coasters separately and count ridden ones within that top 100 instead, so the metric is actually achievable.
- Also drops the hardcoded `c.status = 1`, matching the `Status::OPERATING` name comparison used elsewhere (`CoasterRepository`, `ParkRepository`).

Fixes #301.

## Test plan
- [x] `phpunit` (169 tests, incl. 3 new for this method) — pass
- [x] `phpstan` — no errors
- [x] `php-cs-fixer` — clean
- [x] Verified the new regression test fails against the pre-fix code (hardcoded status id) and passes against the fix