### PR TITLE
feat(map): migrate from Leaflet/CartoDB raster to MapLibre GL vector tiles

### DIFF
--- a/assets/controllers/map_controller.js
+++ b/assets/controllers/map_controller.js
@@ -42,13 +42,18 @@ export default class extends Controller {
         try {
             const maplibregl = await import('maplibre-gl');
             await import('maplibre-gl/dist/maplibre-gl.css');
+            const { version: maplibreGlVersion } = await import(
+                'maplibre-gl/package.json'
+            );
 
             this.maplibregl = maplibregl;
 
             // The worker URL MapLibre resolves at runtime doesn't survive
             // Webpack bundling; see webpack.config.js copyFiles() for why
-            // this static path exists.
-            maplibregl.setWorkerUrl('/build/vendor/maplibre-gl-worker.js');
+            // this static, version-namespaced path exists.
+            maplibregl.setWorkerUrl(
+                `/build/vendor/maplibre-gl-${maplibreGlVersion}/maplibre-gl-worker.js`
+            );
 
             this.map = new maplibregl.Map({
                 container: this.containerTarget,
@@ -61,9 +66,17 @@ export default class extends Controller {
 
             this.map.addControl(new maplibregl.NavigationControl(), 'top-right');
 
+            // 'load' never fires on a style/tile load failure (e.g. an
+            // OpenFreeMap outage) — the try/catch around this method only
+            // covers synchronous setup, not that async case.
+            this.map.on('error', (e) => {
+                console.error('MapLibre error:', e.error);
+            });
+
             this.map.on('load', () => {
                 this.addParksLayer();
                 this.bindLayerInteractions();
+                this.mapLoaded = true;
 
                 if (this.parkIdValue) {
                     this.focusOnPark(this.parkIdValue);
@@ -275,9 +288,14 @@ export default class extends Controller {
         })
             .then((response) => response.json())
             .then((data) => {
+                // If the map hasn't fired 'load' yet, this.markersValue is
+                // still picked up when addParksLayer() eventually builds
+                // the source — nothing more to do here in that case.
                 this.markersValue = data;
-                this.ensureMarkerIcons(data);
-                this.map.getSource(this.SOURCE_ID).setData(this.toGeoJSON(data));
+                if (this.mapLoaded) {
+                    this.ensureMarkerIcons(data);
+                    this.map.getSource(this.SOURCE_ID).setData(this.toGeoJSON(data));
+                }
 
                 const filterElement = document.querySelector(
                     '[data-controller="filter"]'

--- a/assets/controllers/map_controller.js
+++ b/assets/controllers/map_controller.js
@@ -1,16 +1,30 @@
 import { Controller } from '@hotwired/stimulus';
 
 /**
- * Map Controller - Clean Stimulus component for Leaflet maps
- * Handles marker creation, colors, and interactions
+ * Map Controller - Stimulus component for MapLibre GL maps.
+ * Parks are rendered as a single GeoJSON symbol layer, not one DOM node
+ * per marker, so the map stays smooth with thousands of parks.
+ *
+ * MapLibre renders a symbol layer's icons and text labels as two
+ * separate draw batches internally, even within one layer — so even
+ * with icon+text on the same feature, a background marker's label can
+ * still paint over a foreground marker's icon. To get true DOM-marker-
+ * style stacking (like the old Leaflet markers), the circle and its
+ * count are baked into a single raster icon per coaster count — one
+ * pre-rendered image, nothing left to draw separately.
  */
 export default class extends Controller {
     static values = {
-        markers: Array, // Try Array - Stimulus might auto-parse JSON
+        markers: Array,
         parkId: String,
     };
 
     static targets = ['container'];
+
+    SOURCE_ID = 'parks';
+    MARKER_LAYER_ID = 'park-markers';
+    MARKER_ICON_SIZE = 44; // drawn at 2x for retina, see createMarkerIcon()
+    registeredIcons = new Set();
 
     connect() {
         // Make controller accessible for filter functionality
@@ -26,112 +40,173 @@ export default class extends Controller {
 
     async initializeMap() {
         try {
-            // Dynamic import of Leaflet
-            const L = await import('leaflet');
-            await import('leaflet/dist/leaflet.css');
+            const maplibregl = await import('maplibre-gl');
+            await import('maplibre-gl/dist/maplibre-gl.css');
 
-            // Fix default marker icons (Leaflet + Webpack issue)
-            delete L.Icon.Default.prototype._getIconUrl;
-            L.Icon.Default.mergeOptions({
-                iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
-                iconUrl: require('leaflet/dist/images/marker-icon.png'),
-                shadowUrl: require('leaflet/dist/images/marker-shadow.png'),
+            this.maplibregl = maplibregl;
+
+            // The worker URL MapLibre resolves at runtime doesn't survive
+            // Webpack bundling; see webpack.config.js copyFiles() for why
+            // this static path exists.
+            maplibregl.setWorkerUrl('/build/vendor/maplibre-gl-worker.js');
+
+            this.map = new maplibregl.Map({
+                container: this.containerTarget,
+                style: 'https://tiles.openfreemap.org/styles/liberty',
+                center: [6.6323, 46.5197],
+                zoom: 6,
+                minZoom: 2,
+                maxZoom: 18,
             });
 
-            // Create map with world copy jump enabled
-            this.map = L.map(this.containerTarget, {
-                worldCopyJump: true,
-            }).setView([46.5197, 6.6323], 6);
+            this.map.addControl(new maplibregl.NavigationControl(), 'top-right');
 
-            // Add CartoDB Voyager tile layer (colorful, English labels worldwide)
-            L.tileLayer(
-                'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
-                {
-                    attribution: '© OpenStreetMap contributors © CARTO',
-                    maxZoom: 15,
-                    minZoom: 3,
+            this.map.on('load', () => {
+                this.addParksLayer();
+                this.bindLayerInteractions();
+
+                if (this.parkIdValue) {
+                    this.focusOnPark(this.parkIdValue);
+                } else {
+                    this.setUserLocation();
                 }
-            ).addTo(this.map);
-
-            // Store Leaflet reference for internal use
-            this.L = L;
-
-            // Generate markers
-            this.generateMarkers();
-
-            // Handle specific park if provided
-            if (this.parkIdValue) {
-                this.focusOnPark(this.parkIdValue);
-            } else {
-                this.setUserLocation();
-            }
+            });
         } catch (error) {
             console.error('Failed to initialize map:', error);
         }
     }
 
-    generateMarkers() {
-        this.gmarkers = [];
+    colorForCount(nb) {
+        if (nb === 1) return '#22c55e'; // 1 coaster
+        if (nb <= 5) return '#f59e0b'; // 2-5
+        if (nb <= 10) return '#ef4444'; // 6-10
+        if (nb <= 15) return '#dc2626'; // 11-15
+        return '#8b5cf6'; // 15+
+    }
 
-        if (!this.markersValue || this.markersValue.length === 0) {
-            return;
-        }
+    markerIconId(nb) {
+        return `park-marker-${nb}`;
+    }
 
-        this.markersValue.forEach((park) => {
-            const coasterCount = parseInt(park.nb) || 1;
-            const marker = this.L.marker([park.latitude, park.longitude], {
-                icon: this.createCoasterMarker(coasterCount),
-                zIndexOffset: coasterCount * 100, // Higher coaster count = higher z-index
-            }).addTo(this.map);
+    createMarkerIcon(nb) {
+        const size = this.MARKER_ICON_SIZE;
+        const canvas = document.createElement('canvas');
+        canvas.width = size;
+        canvas.height = size;
+        const ctx = canvas.getContext('2d');
 
-            marker.parkId = park.id;
-            marker.title = park.name;
-            this.gmarkers.push(marker);
+        ctx.beginPath();
+        ctx.arc(size / 2, size / 2, size / 2 - 3, 0, Math.PI * 2);
+        ctx.fillStyle = this.colorForCount(nb);
+        ctx.fill();
+        ctx.lineWidth = 3;
+        ctx.strokeStyle = '#ffffff';
+        ctx.stroke();
 
-            marker.on('click', () => {
-                this.loadParkData(marker);
-            });
+        ctx.fillStyle = '#ffffff';
+        ctx.font = `bold ${Math.round(size * 0.42)}px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(String(nb), size / 2, size / 2 + 1);
+
+        return ctx.getImageData(0, 0, size, size);
+    }
+
+    // Registers one raster icon per distinct coaster count so far
+    // unseen — safe to call repeatedly (e.g. after a filter refresh).
+    ensureMarkerIcons(markers) {
+        const counts = new Set((markers || []).map((p) => parseInt(p.nb) || 1));
+        counts.forEach((nb) => {
+            const id = this.markerIconId(nb);
+            if (!this.registeredIcons.has(id)) {
+                this.map.addImage(id, this.createMarkerIcon(nb), { pixelRatio: 2 });
+                this.registeredIcons.add(id);
+            }
         });
     }
 
-    createCoasterMarker(coasterCount) {
-        let color;
-        if (coasterCount === 1) {
-            color = '#22c55e'; // Green - 1 coaster
-        } else if (coasterCount <= 5) {
-            color = '#f59e0b'; // Orange - 2-5 coasters
-        } else if (coasterCount <= 10) {
-            color = '#ef4444'; // Red - 6-10 coasters
-        } else if (coasterCount <= 15) {
-            color = '#dc2626'; // Dark Red - 11-15 coasters
-        } else {
-            color = '#8b5cf6'; // Purple - 15+ coasters
-        }
+    addParksLayer() {
+        this.ensureMarkerIcons(this.markersValue);
 
-        return this.L.divIcon({
-            className: 'coaster-marker',
-            html: `<div class="coaster-marker-inner" data-count="${coasterCount}" style="background: ${color};">${coasterCount}</div>`,
-            iconSize: [20, 20],
-            iconAnchor: [10, 10],
-            popupAnchor: [0, -10],
+        this.map.addSource(this.SOURCE_ID, {
+            type: 'geojson',
+            data: this.toGeoJSON(this.markersValue),
+        });
+
+        this.map.addLayer({
+            id: this.MARKER_LAYER_ID,
+            type: 'symbol',
+            source: this.SOURCE_ID,
+            layout: {
+                'icon-image': ['get', 'icon'],
+                'icon-size': 1,
+                'icon-allow-overlap': true,
+                // Bigger parks draw on top of smaller ones when they
+                // overlap (higher sort-key = drawn later = on top).
+                'symbol-sort-key': ['get', 'nb'],
+            },
         });
     }
 
-    loadParkData(marker) {
-        // Always reload popup data to respect current filters
-        marker.bindPopup('Loading...').openPopup();
+    bindLayerInteractions() {
+        this.map.on('click', this.MARKER_LAYER_ID, (e) => {
+            const feature = e.features[0];
+            this.showParkPopup(feature.properties, feature.geometry.coordinates);
+        });
 
+        this.map.on('mouseenter', this.MARKER_LAYER_ID, () => {
+            this.map.getCanvas().style.cursor = 'pointer';
+        });
+
+        this.map.on('mouseleave', this.MARKER_LAYER_ID, () => {
+            this.map.getCanvas().style.cursor = '';
+        });
+    }
+
+    toGeoJSON(markers) {
+        const features = (markers || []).map((park) => {
+            const nb = parseInt(park.nb) || 1;
+            return {
+                type: 'Feature',
+                properties: {
+                    id: park.id,
+                    name: park.name,
+                    nb,
+                    icon: this.markerIconId(nb),
+                },
+                geometry: {
+                    type: 'Point',
+                    coordinates: [parseFloat(park.longitude), parseFloat(park.latitude)],
+                },
+            };
+        });
+
+        return { type: 'FeatureCollection', features };
+    }
+
+    showParkPopup(properties, coordinates) {
+        if (this.currentPopup) {
+            this.currentPopup.remove();
+        }
+
+        this.currentPopup = new this.maplibregl.Popup({ offset: 12 })
+            .setLngLat(coordinates)
+            .setHTML('Loading...')
+            .addTo(this.map);
+
+        this.loadParkData(properties.id, this.currentPopup);
+    }
+
+    loadParkData(parkId, popup) {
         const url = window.Routing.generate('map_coasters_ajax', {
-            id: marker.parkId,
+            id: parkId,
             _locale: document.documentElement.lang || 'en',
         });
 
-        // Get current form data directly (simple approach)
         const form = document.querySelector('form');
         const formData = new FormData(form);
         const params = new URLSearchParams();
 
-        // Only include non-empty values
         for (const [key, value] of formData.entries()) {
             if (value && value.trim() !== '') {
                 params.set(key, value);
@@ -145,29 +220,35 @@ export default class extends Controller {
         })
             .then((response) => response.text())
             .then((coasters) => {
-                marker.bindPopup(coasters).openPopup();
+                popup.setHTML(coasters);
             })
             .catch((error) => {
                 console.error('Failed to load park data:', error);
-                marker.bindPopup('Error loading data').openPopup();
+                popup.setHTML('Error loading data');
             });
     }
 
     focusOnPark(parkId) {
-        const park = this.gmarkers.find((marker) => marker.parkId == parkId);
+        const park = (this.markersValue || []).find((p) => p.id == parkId);
         if (park) {
-            this.map.setView([park.getLatLng().lat, park.getLatLng().lng], 9);
-            this.loadParkData(park);
+            const coordinates = [parseFloat(park.longitude), parseFloat(park.latitude)];
+            this.map.setCenter(coordinates);
+            this.map.setZoom(9);
+            this.showParkPopup(
+                { id: park.id, name: park.name, nb: parseInt(park.nb) || 1 },
+                coordinates
+            );
         }
     }
 
     setUserLocation() {
         if (navigator.geolocation) {
             navigator.geolocation.getCurrentPosition((position) => {
-                this.map.setView(
-                    [position.coords.latitude, position.coords.longitude],
-                    5
-                );
+                this.map.setCenter([
+                    position.coords.longitude,
+                    position.coords.latitude,
+                ]);
+                this.map.setZoom(5);
             });
         }
     }
@@ -181,7 +262,6 @@ export default class extends Controller {
         const formData = new FormData(form);
         const params = new URLSearchParams();
 
-        // Only include non-empty values
         for (const [key, value] of formData.entries()) {
             if (value && value.trim() !== '') {
                 params.set(key, value);
@@ -195,11 +275,10 @@ export default class extends Controller {
         })
             .then((response) => response.json())
             .then((data) => {
-                this.removeMarkers();
                 this.markersValue = data;
-                this.generateMarkers();
+                this.ensureMarkerIcons(data);
+                this.map.getSource(this.SOURCE_ID).setData(this.toGeoJSON(data));
 
-                // Update browser URL if filter controller has URL updates enabled
                 const filterElement = document.querySelector(
                     '[data-controller="filter"]'
                 );
@@ -213,14 +292,5 @@ export default class extends Controller {
             .catch((error) => {
                 console.error('Failed to filter markers:', error);
             });
-    }
-
-    removeMarkers() {
-        if (this.gmarkers) {
-            this.gmarkers.forEach((marker) => {
-                this.map.removeLayer(marker);
-            });
-            this.gmarkers = [];
-        }
     }
 }

--- a/assets/styles/components/map.css
+++ b/assets/styles/components/map.css
@@ -5,11 +5,13 @@
  */
 
 /* .content-wrapper is a table-cell sized by its content, so height:100%
-   on the map is circular (resolves to 0). Match the theme's own navbar
-   height (@navbar-height in variables-core.less) instead of guessing a
-   vh percentage, which always left a blank strip below the map. */
+   on the map is circular (resolves to 0). .content-wrapper itself is
+   sized to a flat 100vh by the theme despite starting below the navbar,
+   so it already overflows the viewport by the navbar's height — match
+   that exact sizing (not vh minus navbar) so #map fills it completely
+   instead of stopping short and leaving a scrollable blank strip. */
 #map {
-    height: calc(100vh - 46px);
+    height: 100vh;
 }
 
 /* Popup styling */

--- a/assets/styles/components/map.css
+++ b/assets/styles/components/map.css
@@ -4,6 +4,14 @@
  * GeoJSON layer, styled via paint expressions in map_controller.js)
  */
 
+/* .content-wrapper is a table-cell sized by its content, so height:100%
+   on the map is circular (resolves to 0). Match the theme's own navbar
+   height (@navbar-height in variables-core.less) instead of guessing a
+   vh percentage, which always left a blank strip below the map. */
+#map {
+    height: calc(100vh - 46px);
+}
+
 /* Popup styling */
 .maplibregl-popup-content {
     font-size: 14px;

--- a/assets/styles/components/map.css
+++ b/assets/styles/components/map.css
@@ -1,56 +1,34 @@
 /**
  * Map Component Styles
- * Clean CSS for Leaflet map markers and popups
+ * Clean CSS for MapLibre GL popups (park markers are rendered as a
+ * GeoJSON layer, styled via paint expressions in map_controller.js)
  */
 
-/* Marker styling */
-.coaster-marker {
-    background: transparent !important;
-    border: none !important;
-}
-
-.coaster-marker-inner {
-    color: white;
-    border-radius: 50%;
-    width: 20px;
-    height: 20px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 11px;
-    font-weight: bold;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-    border: 2px solid white;
-    transition: transform 0.2s ease;
-}
-
-.coaster-marker-inner:hover {
-    transform: scale(1.1);
-}
-
 /* Popup styling */
-.leaflet-popup-content-wrapper {
+.maplibregl-popup-content {
     font-size: 14px;
     border-radius: 8px;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
     border: none;
     background: white;
-}
-
-.leaflet-popup-content {
-    margin: 12px 16px;
+    margin: 0;
+    padding: 12px 16px;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     line-height: 1.4;
 }
 
-.leaflet-popup-tip {
-    background: white;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+.maplibregl-popup-tip {
+    border-top-color: white;
+    border-bottom-color: white;
 }
 
 /* Popup content */
 .popup-park-name {
     margin: 0 0 6px 0;
+    /* Reserve space so long titles wrap before reaching the close button
+       instead of running underneath it (button is absolutely positioned
+       top-right by MapLibre's default popup CSS). */
+    padding-right: 24px;
     font-size: 15px;
     font-weight: 600;
     color: #1f2937 !important;
@@ -95,15 +73,17 @@
 }
 
 /* Close button */
-.leaflet-popup-close-button {
+.maplibregl-popup-close-button {
     color: #6b7280;
     font-size: 18px;
     font-weight: bold;
     padding: 8px;
     width: auto;
     height: auto;
+    top: 4px;
+    right: 4px;
 }
 
-.leaflet-popup-close-button:hover {
+.maplibregl-popup-close-button:hover {
     color: #374151;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "bootstrap": "^3.4.1",
         "jquery": "^3.7.1",
-        "leaflet": "^1.9.4",
+        "maplibre-gl": "^6.6.0",
         "sortablejs": "^1.15.6"
       },
       "devDependencies": {
@@ -2371,6 +2371,92 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 22"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
+      "integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^5.0.0"
+      }
+    },
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
+      "integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.1.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.4.1.tgz",
+      "integrity": "sha512-I/qcIKVFHFSg1Meu/eqHrkSTjIez0gCsSaK56TNPutM3TkE61aSq6F1cZ4Kg4KiNs3cpViLtubDjfyRcQCdEJQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
+        "@mapbox/unitbezier": "^1.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.2.0.tgz",
+      "integrity": "sha512-g45M8gEI4sMO3X9ib4K7n3ZKFf0qQOL+NMkHCnEK51lOrYFHiEssOuZncx1+miIgi1IEE2NcbRMcq8RBkL+QHA==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.2.tgz",
+      "integrity": "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^5.1.0"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
@@ -3189,6 +3275,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
@@ -5246,6 +5338,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/earcut": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
+      "license": "ISC"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5875,6 +5973,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
@@ -6672,6 +6776,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -6684,6 +6794,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
+      "license": "ISC"
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -6705,12 +6821,6 @@
         "picocolors": "^1.1.1",
         "shell-quote": "^1.8.4"
       }
-    },
-    "node_modules/leaflet": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/less": {
       "version": "4.9.0",
@@ -7164,6 +7274,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/maplibre-gl": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.6.0.tgz",
+      "integrity": "sha512-EQql6eZYPhbHvJpqY4AwoiuLkUfXFRBHk67S8mDtzNo1F/jAo7xAxunIzO7gJ1vwTcPMgrK9b64dqKHvnkTlDQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.2.0",
+        "@mapbox/unitbezier": "^1.0.0",
+        "@mapbox/vector-tile": "^3.0.0",
+        "@maplibre/geojson-vt": "^6.1.1",
+        "@maplibre/maplibre-gl-style-spec": "^26.3.0",
+        "@maplibre/mlt": "^1.2.0",
+        "@maplibre/vt-pbf": "^4.3.2",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.2.3",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.1.0",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^5.1.2",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7356,6 +7498,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minimizer-webpack-plugin": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
@@ -7462,6 +7613,12 @@
       "bin": {
         "multicast-dns": "cli.js"
       }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.18",
@@ -7849,6 +8006,18 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pbf": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8555,6 +8724,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
     "node_modules/prettier": {
       "version": "3.9.6",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
@@ -8684,6 +8859,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -8762,6 +8943,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -9033,6 +9220,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "node_modules/resolve-url-loader": {
@@ -10090,6 +10286,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "bootstrap": "^3.4.1",
     "jquery": "^3.7.1",
-    "leaflet": "^1.9.4",
+    "maplibre-gl": "^6.6.0",
     "sortablejs": "^1.15.6"
   },
   "overrides": {

--- a/templates/Maps/index.html.twig
+++ b/templates/Maps/index.html.twig
@@ -34,7 +34,7 @@
          data-map-markers-value="{{ markers|json_encode }}"
          data-map-park-id-value="{{ parkId|default('') }}"
          class="map-container">
-        <div data-map-target="container" id="map" style="height:94vh;"></div>
+        <div data-map-target="container" id="map"></div>
     </div>
 {% endblock %}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,11 @@
 const Encore = require("@symfony/webpack-encore");
 const path = require("path");
 
+// Single source of truth for the versioned vendor/ path below and the
+// matching setWorkerUrl() call in map_controller.js — keeps the two in
+// sync automatically whenever the maplibre-gl dependency is bumped.
+const maplibreGlVersion = require("maplibre-gl/package.json").version;
+
 // Manually configure the runtime environment if not already configured yet by the "encore" command.
 // It's useful when you use tools that rely on webpack.config.js file.
 if (!Encore.isRuntimeEnvironmentConfigured()) {
@@ -120,10 +125,15 @@ Encore
     // dynamically at runtime — that resolution doesn't survive Webpack
     // bundling, so the worker silently fails to start. Copying the worker
     // script as a static asset and pointing setWorkerUrl() at it (in
-    // map_controller.js) works around this.
+    // map_controller.js) works around this. The destination is namespaced
+    // under the installed maplibre-gl version (not Encore's usual content
+    // hash — the worker's own source imports its sibling file by a fixed
+    // relative filename, so hashing filenames independently would break
+    // that) so a version bump can't leave a stale worker/shared file
+    // cached under a URL a fresh main bundle still points at.
     .copyFiles({
         from: "./node_modules/maplibre-gl/dist",
-        to: "vendor/maplibre-gl-worker.js",
+        to: `vendor/maplibre-gl-${maplibreGlVersion}/maplibre-gl-worker.js`,
         pattern: /maplibre-gl-worker\.mjs$/,
     })
     // The worker's own source imports "./maplibre-gl-shared.mjs" as a
@@ -131,7 +141,7 @@ Encore
     // exactly for that import to resolve next to it.
     .copyFiles({
         from: "./node_modules/maplibre-gl/dist",
-        to: "vendor/[name].[ext]",
+        to: `vendor/maplibre-gl-${maplibreGlVersion}/[name].[ext]`,
         pattern: /maplibre-gl-shared\.mjs$/,
     })
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -116,6 +116,25 @@ Encore
     //     includeSubdirectories: true,
     // })
 
+    // MapLibre GL parses vector tiles in a Web Worker whose URL it resolves
+    // dynamically at runtime — that resolution doesn't survive Webpack
+    // bundling, so the worker silently fails to start. Copying the worker
+    // script as a static asset and pointing setWorkerUrl() at it (in
+    // map_controller.js) works around this.
+    .copyFiles({
+        from: "./node_modules/maplibre-gl/dist",
+        to: "vendor/maplibre-gl-worker.js",
+        pattern: /maplibre-gl-worker\.mjs$/,
+    })
+    // The worker's own source imports "./maplibre-gl-shared.mjs" as a
+    // relative module specifier — filename and .mjs extension must match
+    // exactly for that import to resolve next to it.
+    .copyFiles({
+        from: "./node_modules/maplibre-gl/dist",
+        to: "vendor/[name].[ext]",
+        pattern: /maplibre-gl-shared\.mjs$/,
+    })
+
     // Configure bundle splitting for stable vendor libraries
     .configureSplitChunks((splitChunks) => {
         splitChunks.cacheGroups = {


### PR DESCRIPTION
## Summary
- CartoDB's free raster basemap started showing an "API KEY REQUIRED" overlay, breaking the coasters map. Moved to MapLibre GL against OpenFreeMap's free, no-key vector tiles instead of another key-gated raster host.
- Dropped Leaflet entirely; parks render as a single GeoJSON symbol layer instead of one DOM marker per park, which also fixes map lag/jank with hundreds of parks on screen.
- Marker circle + coaster-count label are baked into one pre-rendered raster icon per distinct coaster count, not separate icon/text style properties on the symbol layer — MapLibre renders a symbol layer's icons and text as two separate draw batches even within one layer, so anything short of a single baked icon produced orphaned labels floating over unrelated markers once overlap was allowed. `symbol-sort-key` stacks higher-coaster-count parks on top of smaller ones, matching the old Leaflet `zIndexOffset` behavior.
- `webpack.config.js` copies MapLibre's worker script + its module dependency as static assets and points `setWorkerUrl()` at them — MapLibre's default worker-URL resolution doesn't survive Webpack bundling and fails silently (raster tiles still rendered fine since those don't need the worker, which is what made this easy to miss).
- Ported `.leaflet-popup-*` CSS rules to `.maplibregl-popup-*`; reserved space in the popup title for the close button so long park names don't collide with it.

## Test plan
- [x] Map loads and renders the vector basemap with no console errors
- [x] Verified at real data scale (~1,800 parks): all markers render, correct colors/counts, no orphaned labels in dense clusters (Ruhr/Benelux)
- [x] Marker click → popup → AJAX coaster list works
- [x] Filter sidebar refresh (`filterData()` outlet contract) updates markers without errors
- [x] Overlapping markers stack with highest coaster-count on top (verified against Europa Park / Funny-World Kappel overlap)
- [x] Popup close button no longer collides with long park titles (e.g. "Jardin d'Acclimatation")
- [x] `npm run build` compiles clean; MapLibre chunk (~270KB gzip) confirmed lazy-loaded only on the map page, not on other pages
- [x] `vendor/bin/phpstan analyse` passes (no PHP changed, sanity check only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScUDvmvEX5ycJQjeieecFf