### PR TITLE
fix(map): clicking overlapping markers always opened the smallest one

### DIFF
--- a/assets/controllers/map_controller.js
+++ b/assets/controllers/map_controller.js
@@ -163,7 +163,13 @@ export default class extends Controller {
 
     bindLayerInteractions() {
         this.map.on('click', this.MARKER_LAYER_ID, (e) => {
-            const feature = e.features[0];
+            // e.features isn't ordered by visual stacking (same quirk as
+            // queryRenderedFeatures) — pick by nb, same rule symbol-sort-key
+            // uses to decide which marker draws on top, so the one that
+            // opens is the one the user can actually see.
+            const feature = e.features.reduce((top, f) =>
+                f.properties.nb > top.properties.nb ? f : top
+            );
             this.showParkPopup(feature.properties, feature.geometry.coordinates);
         });
 


### PR DESCRIPTION
## Summary
- `e.features` from a MapLibre symbol layer click hit-test isn't ordered by visual stacking (same quirk as `queryRenderedFeatures`, which the previous PR's stacking fix already ran into) — `e.features[0]` silently ignored `symbol-sort-key` and opened whichever marker happened first in the hit-test list, not the one actually visible on top.
- Fix: pick the feature with the highest `nb` among `e.features`, same rule `symbol-sort-key` already uses to decide which marker draws on top.

## Test plan
- [x] Reproduced against the exact Europa Park (14 coasters) / Funny-World Kappel (1 coaster) overlap: before the fix, clicking there opened Funny-World Kappel; after, it correctly opens Europa Park
- [x] Verified via a real simulated click (canvas mouse events), not a direct method call
- [x] No console errors