### PR TITLE
fix(filter): keep filters when switching locale on Map/Ranking/Search

### DIFF
--- a/assets/controllers/filter_controller.js
+++ b/assets/controllers/filter_controller.js
@@ -224,6 +224,17 @@ export default class extends Controller {
             window.location.pathname + (queryString ? '?' + queryString : '');
 
         window.history.pushState(null, '', newUrl);
+        this.updateLanguageSwitcherLinks(queryString);
+    }
+
+    // The language switcher's locale links are rendered server-side from
+    // the query string at initial page load. Filters applied afterward
+    // only exist in pushState (see above), so without this the switcher
+    // silently drops them when the user changes locale mid-filter.
+    updateLanguageSwitcherLinks(queryString) {
+        document.querySelectorAll('.language-switch a[href]').forEach((link) => {
+            link.search = queryString;
+        });
     }
 
     // Restore filters from URL on page load


### PR DESCRIPTION
## Summary
Closes #256

The language switcher's locale links are rendered server-side from the query string at initial page load (`navbar.html.twig` already merges `app.request.query.all` correctly). But Map/Ranking/Search filters are applied client-side via `pushState`, not a real navigation — so once a user changes a filter, the switcher's links go stale and silently drop it on locale change.

`updateBrowserUrl()` already builds the exact query string needed; reuse it to also patch the switcher's `href`s whenever filters change. Fix lives in the shared `filter_controller.js`, so it covers Map, Ranking, and Coaster Search — all three use the same controller.

## Test plan
- [x] Applied a filter on the Map page, confirmed the switcher's locale links picked up the query string
- [x] Navigated through a switcher link to `/fr/map/`, confirmed the filter was restored on load (existing `restoreFiltersFromUrl()`)
- [x] Confirmed Ranking and Coaster Search templates both set `update_url: true`, same controller applies
- [x] No console errors