### PR TITLE
feat(preferences): locale, units, and review-language preferences

### DIFF
--- a/assets/js/theme/theme.js
+++ b/assets/js/theme/theme.js
@@ -82,6 +82,7 @@ $(function () {
     // Mobile sidebar toggles
     $('.sidebar-mobile-main-toggle').on('click', function (e) {
         e.preventDefault();
+        $('#navbar-mobile').collapse('hide');
         $('body')
             .toggleClass('sidebar-mobile-main')
             .removeClass(
@@ -91,11 +92,21 @@ $(function () {
 
     $('.sidebar-mobile-secondary-toggle').on('click', function (e) {
         e.preventDefault();
+        $('#navbar-mobile').collapse('hide');
         $('body')
             .toggleClass('sidebar-mobile-secondary')
             .removeClass(
                 'sidebar-mobile-main sidebar-mobile-opposite sidebar-mobile-detached'
             );
+    });
+
+    // Opening the account/language collapse should close either sidebar,
+    // same as the sidebar toggles already close each other above --
+    // otherwise both panels can end up stacked open at once on mobile.
+    $('[data-target="#navbar-mobile"]').on('click', function () {
+        $('body').removeClass(
+            'sidebar-mobile-main sidebar-mobile-secondary sidebar-mobile-opposite sidebar-mobile-detached'
+        );
     });
 
     // Window resize handling

--- a/assets/styles/app.less
+++ b/assets/styles/app.less
@@ -120,6 +120,7 @@
 @import 'components/section-header.css';
 @import 'components/tooltip.css';
 @import 'components/notifications.css';
+@import 'components/account-menu.less';
 
 // Import utilities
 @import 'icons/icons.css';

--- a/assets/styles/components/account-menu.less
+++ b/assets/styles/components/account-menu.less
@@ -30,3 +30,44 @@
     color: #767676;
     font-size: 12px;
 }
+
+// On mobile the collapsed navbar already required one tap to reveal
+// #navbar-mobile; requiring a second tap on a nested dropdown-toggle to
+// reveal the account menu duplicates that icon and shows an empty row
+// while the menu stays hidden. Render it inline instead, unconditionally,
+// reusing the theme's own inverse-navbar mobile dropdown colors (normally
+// gated behind `.open`, which this bypasses) so text stays legible against
+// the dark collapsed navbar background.
+@media (max-width: @grid-float-breakpoint-max) {
+    .dropdown-user > .dropdown-toggle,
+    .account-menu-anon > .dropdown-toggle {
+        display: none;
+    }
+    .navbar-nav > li > .dropdown-menu.account-menu {
+        display: block;
+        position: static;
+        float: none;
+        width: auto;
+        margin: 0;
+        border: 0;
+        box-shadow: none;
+        background-color: transparent;
+        color: @navbar-inverse-link-color;
+
+        a:not(.label-flat):not(.badge-flat) {
+            color: @navbar-inverse-link-color;
+        }
+
+        .divider {
+            background-color: fade(#fff, 10%);
+        }
+
+        .account-menu-row-value {
+            color: fade(@navbar-inverse-link-color, 70%);
+        }
+
+        .account-menu-row:hover {
+            background-color: fade(#000, 10%);
+        }
+    }
+}

--- a/assets/styles/components/account-menu.less
+++ b/assets/styles/components/account-menu.less
@@ -3,20 +3,20 @@
     align-items: center;
     gap: 10px;
     padding: 12px 15px 10px;
+
+    // The theme caps any avatar under .dropdown-user at max-height: 30px
+    // (sized for the compact toggle-button avatar) with no !important --
+    // since max-height is a different property than img-lg's own
+    // `height: 44px !important`, that cap still wins and squashes this
+    // larger header avatar into an oval. img-lg's own !important is the
+    // established way to fight this theme's image-sizing rules, so match it.
+    img {
+        max-height: none !important;
+        border: 2px solid fade(#000, 10%);
+    }
 }
 .account-menu-name {
     font-weight: 600;
-}
-.account-menu-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    padding: 8px 15px;
-    cursor: pointer;
-}
-.account-menu-row:hover {
-    background-color: #f5f5f5;
 }
 .account-menu-row-label {
     display: flex;
@@ -29,6 +29,36 @@
     gap: 4px;
     color: #767676;
     font-size: 12px;
+}
+
+// Every row in the panel -- plain links (Settings, My ratings, Logout...),
+// account-menu-row triggers (language, units, notifications), and their
+// nested submenu options (English, Metric units...) alike -- shares this
+// same icon/text + gap layout, so it lives on one shared selector instead
+// of being duplicated per row type. Descendant (not child) combinator: it
+// also needs to reach submenu option links two levels deeper.
+.account-menu li > a {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 15px;
+}
+// account-menu-row rows, and submenu options, additionally push something
+// (current value, unread count, the selected-option checkmark) to the right.
+.account-menu-row,
+.dropdown-submenu .dropdown-menu > li > a {
+    justify-content: space-between;
+}
+
+// The theme draws its own submenu-opens-here arrow via a background-image
+// data URI on ::after, positioned absolutely at a fixed right offset. Two
+// problems for our rows specifically: it can't pick up currentColor (it's
+// a rasterized image, not a live SVG), so it stays dark and unreadable
+// against this dark panel; and being absolutely positioned, it overlaps
+// long value text ("Unités métriques") instead of flowing after it. Our
+// own chevron-right icon inside account-menu-row-value replaces it.
+.dropdown-submenu > a.account-menu-row:after {
+    display: none;
 }
 
 // On mobile the collapsed navbar already required one tap to reveal
@@ -66,8 +96,57 @@
             color: fade(@navbar-inverse-link-color, 70%);
         }
 
-        .account-menu-row:hover {
+        .account-menu-header img {
+            border-color: fade(#fff, 20%);
+        }
+
+        // Every link's hover/focus/active state (not just .account-menu-row)
+        // -- otherwise plain rows (Settings, Logout, submenu option lists...)
+        // keep Bootstrap's light default tap-highlight background, which
+        // flashes white against this dark panel.
+        li > a:hover,
+        li > a:focus,
+        li > a:active {
             background-color: fade(#000, 10%);
         }
+
+        // Nested submenus (language, units, notifications) are themselves
+        // .dropdown-menu elements; the theme's own mobile stacking rules
+        // reset their position and box-shadow but not their light default
+        // background or their navbar-inverse border, which otherwise
+        // render as a boxed-in white panel with a visible double line
+        // (its own border plus the next divider right below it) inside
+        // this dark, borderless account panel.
+        .dropdown-menu {
+            background-color: transparent;
+            border: none;
+            box-shadow: none;
+        }
+    }
+
+    // Match the desktop toggle exactly: same 32px avatar (img-xs), same
+    // 6.5px 15px padding as .dropdown-toggle there -- so the mobile navbar
+    // bar comes out the same height as desktop's, not taller.
+    // Specificity note: ".navbar-toggle-icon > a" needs to beat Bootstrap
+    // core's ".nav > li > a" (0,1,2), hence "li." rather than the class alone.
+    li.navbar-toggle-icon > a {
+        display: flex;
+        align-items: center;
+        padding: 6.5px 15px;
+        line-height: 0;
+    }
+    .navbar-toggle-icon img,
+    .navbar-toggle-icon svg {
+        width: 32px;
+        height: 32px;
+    }
+
+    // Bootstrap's own .navbar-collapse.collapse caps this at 340px with an
+    // inner scrollbar (fine for a short nav list, not for a full account
+    // panel). Let it grow to its content height and let the page scroll
+    // instead of an inner scroll box.
+    #navbar-mobile.collapse {
+        max-height: none;
+        overflow-y: visible;
     }
 }

--- a/assets/styles/components/account-menu.less
+++ b/assets/styles/components/account-menu.less
@@ -1,3 +1,15 @@
+// Desktop navbar toggle avatar: smaller and ringed. Unlike the
+// account-menu-header avatar (which sits on the dropdown panel's light
+// background and so uses a dark fade(#000,10%) border), this one sits on
+// the dark top navbar in both mobile and desktop, so it needs the panel's
+// own dark-background variant (fade(#fff,20%), see the mobile media query
+// below) to actually be visible.
+.dropdown-user > .dropdown-toggle img {
+    width: 28px !important;
+    height: 28px !important;
+    border: 2px solid fade(#fff, 20%);
+}
+
 .account-menu-header {
     display: flex;
     align-items: center;
@@ -124,22 +136,31 @@
         }
     }
 
-    // Match the desktop toggle exactly: same 32px avatar (img-xs), same
-    // 6.5px 15px padding as .dropdown-toggle there -- so the mobile navbar
-    // bar comes out the same height as desktop's, not taller.
+    // Pin this one <li> to .navbar-header's own fixed height (46px) and
+    // center its content within that full height -- not a hand-tuned
+    // padding value, so it stays correct regardless of whether the icon
+    // inside is the 28px ringed avatar or the smaller plain svg.
     // Specificity note: ".navbar-toggle-icon > a" needs to beat Bootstrap
     // core's ".nav > li > a" (0,1,2), hence "li." rather than the class alone.
-    li.navbar-toggle-icon > a {
-        display: flex;
-        align-items: center;
-        padding: 6.5px 15px;
-        line-height: 0;
+    li.navbar-toggle-icon {
+        height: 46px;
+
+        > a {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100%;
+            padding: 0 15px;
+            line-height: 0;
+        }
     }
-    .navbar-toggle-icon img,
-    .navbar-toggle-icon svg {
-        width: 32px;
-        height: 32px;
+    .navbar-toggle-icon img {
+        width: 28px !important;
+        height: 28px !important;
+        border: 2px solid fade(#fff, 20%);
     }
+    // No size override for svg: it falls back to its natural w-8/h-8 size,
+    // same as the burger icon beside it.
 
     // Bootstrap's own .navbar-collapse.collapse caps this at 340px with an
     // inner scrollbar (fine for a short nav list, not for a full account

--- a/assets/styles/components/account-menu.less
+++ b/assets/styles/components/account-menu.less
@@ -1,0 +1,32 @@
+.account-menu-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 15px 10px;
+}
+.account-menu-name {
+    font-weight: 600;
+}
+.account-menu-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 8px 15px;
+    cursor: pointer;
+}
+.account-menu-row:hover {
+    background-color: #f5f5f5;
+}
+.account-menu-row-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.account-menu-row-value {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    color: #767676;
+    font-size: 12px;
+}

--- a/migrations/Version20260829120000.php
+++ b/migrations/Version20260829120000.php
@@ -16,15 +16,15 @@ final class Version20260829120000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql("ALTER TABLE user ADD preferred_units VARCHAR(20) DEFAULT 'metric' NOT NULL");
-        $this->addSql("UPDATE user SET preferred_units = 'imperial' WHERE imperial = 1");
-        $this->addSql('ALTER TABLE user DROP imperial');
+        $this->addSql("ALTER TABLE users ADD preferred_units VARCHAR(20) DEFAULT 'metric' NOT NULL");
+        $this->addSql("UPDATE users SET preferred_units = 'imperial' WHERE imperial = 1");
+        $this->addSql('ALTER TABLE users DROP imperial');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE user ADD imperial TINYINT(1) DEFAULT 0 NOT NULL');
-        $this->addSql("UPDATE user SET imperial = 1 WHERE preferred_units = 'imperial'");
-        $this->addSql('ALTER TABLE user DROP preferred_units');
+        $this->addSql('ALTER TABLE users ADD imperial TINYINT(1) DEFAULT 0 NOT NULL');
+        $this->addSql("UPDATE users SET imperial = 1 WHERE preferred_units = 'imperial'");
+        $this->addSql('ALTER TABLE users DROP preferred_units');
     }
 }

--- a/migrations/Version20260829120000.php
+++ b/migrations/Version20260829120000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260829120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Replace user.imperial boolean with user.preferred_units string (metric|imperial)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE user ADD preferred_units VARCHAR(20) DEFAULT 'metric' NOT NULL");
+        $this->addSql("UPDATE user SET preferred_units = 'imperial' WHERE imperial = 1");
+        $this->addSql('ALTER TABLE user DROP imperial');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user ADD imperial TINYINT(1) DEFAULT 0 NOT NULL');
+        $this->addSql("UPDATE user SET imperial = 1 WHERE preferred_units = 'imperial'");
+        $this->addSql('ALTER TABLE user DROP preferred_units');
+    }
+}

--- a/migrations/Version20260829130000.php
+++ b/migrations/Version20260829130000.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260829130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Replace user.display_reviews_in_all_languages boolean with user.preferred_review_languages JSON array';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user ADD preferred_review_languages JSON NOT NULL');
+        // Preserve the explicit "show everything" choice for users who had
+        // it on; everyone else (the default) gets an empty array, which
+        // means "only my own language" -- a deliberate behavior change
+        // from the old default of "mine first, others still visible".
+        $this->addSql('UPDATE user SET preferred_review_languages = \'["en","fr","es","de"]\' WHERE display_reviews_in_all_languages = 1');
+        $this->addSql('UPDATE user SET preferred_review_languages = \'[]\' WHERE display_reviews_in_all_languages = 0');
+        $this->addSql('ALTER TABLE user DROP display_reviews_in_all_languages');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user ADD display_reviews_in_all_languages TINYINT(1) DEFAULT 0 NOT NULL');
+        $this->addSql('UPDATE user SET display_reviews_in_all_languages = 1 WHERE JSON_LENGTH(preferred_review_languages) > 0');
+        $this->addSql('ALTER TABLE user DROP preferred_review_languages');
+    }
+}

--- a/migrations/Version20260829130000.php
+++ b/migrations/Version20260829130000.php
@@ -16,20 +16,20 @@ final class Version20260829130000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE user ADD preferred_review_languages JSON NOT NULL');
+        $this->addSql('ALTER TABLE users ADD preferred_review_languages JSON NOT NULL');
         // Preserve the explicit "show everything" choice for users who had
         // it on; everyone else (the default) gets an empty array, which
         // means "only my own language" -- a deliberate behavior change
         // from the old default of "mine first, others still visible".
-        $this->addSql('UPDATE user SET preferred_review_languages = \'["en","fr","es","de"]\' WHERE display_reviews_in_all_languages = 1');
-        $this->addSql('UPDATE user SET preferred_review_languages = \'[]\' WHERE display_reviews_in_all_languages = 0');
-        $this->addSql('ALTER TABLE user DROP display_reviews_in_all_languages');
+        $this->addSql('UPDATE users SET preferred_review_languages = \'["en","fr","es","de"]\' WHERE display_reviews_in_all_languages = 1');
+        $this->addSql('UPDATE users SET preferred_review_languages = \'[]\' WHERE display_reviews_in_all_languages = 0');
+        $this->addSql('ALTER TABLE users DROP display_reviews_in_all_languages');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE user ADD display_reviews_in_all_languages TINYINT(1) DEFAULT 0 NOT NULL');
-        $this->addSql('UPDATE user SET display_reviews_in_all_languages = 1 WHERE JSON_LENGTH(preferred_review_languages) > 0');
-        $this->addSql('ALTER TABLE user DROP preferred_review_languages');
+        $this->addSql('ALTER TABLE users ADD display_reviews_in_all_languages TINYINT(1) DEFAULT 0 NOT NULL');
+        $this->addSql('UPDATE users SET display_reviews_in_all_languages = 1 WHERE JSON_LENGTH(preferred_review_languages) > 0');
+        $this->addSql('ALTER TABLE users DROP preferred_review_languages');
     }
 }

--- a/migrations/Version20260829130000.php
+++ b/migrations/Version20260829130000.php
@@ -16,7 +16,7 @@ final class Version20260829130000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE users ADD preferred_review_languages JSON NOT NULL');
+        $this->addSql('ALTER TABLE users ADD preferred_review_languages JSON DEFAULT \'[]\' NOT NULL');
         // Preserve the explicit "show everything" choice for users who had
         // it on; everyone else (the default) gets an empty array, which
         // means "only my own language" -- a deliberate behavior change

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -13,6 +13,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ArrayField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
@@ -88,7 +89,9 @@ class UserCrudController extends AbstractCrudController
         yield TextField::new('preferredLocale')->onlyOnForms();
         yield BooleanField::new('emailNotification')->onlyOnForms();
         yield BooleanField::new('addTodayDateWhenRating')->onlyOnForms();
-        yield BooleanField::new('imperial')->onlyOnForms();
+        yield ChoiceField::new('preferredUnits')
+            ->setChoices(['Metric' => 'metric', 'Imperial' => 'imperial'])
+            ->onlyOnForms();
         yield BooleanField::new('displayReviewsInAllLanguages')->onlyOnForms();
 
         // Edit page - Access

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -92,7 +92,7 @@ class UserCrudController extends AbstractCrudController
         yield ChoiceField::new('preferredUnits')
             ->setChoices(['Metric' => 'metric', 'Imperial' => 'imperial'])
             ->onlyOnForms();
-        yield BooleanField::new('displayReviewsInAllLanguages')->onlyOnForms();
+        yield ArrayField::new('preferredReviewLanguages')->onlyOnForms();
 
         // Edit page - Access
         yield FormField::addPanel('Access')->onlyOnForms();

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -18,12 +18,20 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * @extends AbstractCrudController<User>
  */
 class UserCrudController extends AbstractCrudController
 {
+    /** @param array<string> $locales */
+    public function __construct(
+        #[Autowire(param: 'app_locales_array')]
+        private readonly array $locales,
+    ) {
+    }
+
     public static function getEntityFqcn(): string
     {
         return User::class;
@@ -92,7 +100,10 @@ class UserCrudController extends AbstractCrudController
         yield ChoiceField::new('preferredUnits')
             ->setChoices(['Metric' => 'metric', 'Imperial' => 'imperial'])
             ->onlyOnForms();
-        yield ArrayField::new('preferredReviewLanguages')->onlyOnForms();
+        yield ChoiceField::new('preferredReviewLanguages')
+            ->setChoices(array_combine($this->locales, $this->locales))
+            ->allowMultipleChoices()
+            ->onlyOnForms();
 
         // Edit page - Access
         yield FormField::addPanel('Access')->onlyOnForms();

--- a/src/Controller/CoasterController.php
+++ b/src/Controller/CoasterController.php
@@ -166,7 +166,7 @@ class CoasterController extends BaseController
         $preferredReviewLanguages = $reviewLanguagePreferenceService->resolve($request);
 
         $pagination = $paginator->paginate(
-            $riddenCoasterRepository->getCoasterReviews($coaster, $preferredReviewLanguages[0] ?? $request->getLocale(), false, $filters),
+            $riddenCoasterRepository->getCoasterReviews($coaster, $preferredReviewLanguages, $filters),
             $page,
             25
         );

--- a/src/Controller/CoasterController.php
+++ b/src/Controller/CoasterController.php
@@ -12,6 +12,7 @@ use App\Repository\CoasterRepository;
 use App\Repository\CoasterSummaryRepository;
 use App\Repository\RiddenCoasterRepository;
 use App\Service\ImageManager;
+use App\Service\ReviewLanguagePreferenceService;
 use App\Service\SummaryFeedbackService;
 use Doctrine\ORM\EntityManagerInterface;
 use Knp\Component\Pager\PaginatorInterface;
@@ -160,16 +161,12 @@ class CoasterController extends BaseController
         methods: ['GET'],
         condition: 'request.isXmlHttpRequest()'
     )]
-    public function ajaxLoadReviews(Request $request, RiddenCoasterRepository $riddenCoasterRepository, PaginatorInterface $paginator, #[MapEntity(mapping: ['slug' => 'slug'])] Coaster $coaster, #[MapQueryParameter] int $page = 1, #[MapQueryParameter] array $filters = []): Response
+    public function ajaxLoadReviews(Request $request, RiddenCoasterRepository $riddenCoasterRepository, PaginatorInterface $paginator, #[MapEntity(mapping: ['slug' => 'slug'])] Coaster $coaster, ReviewLanguagePreferenceService $reviewLanguagePreferenceService, #[MapQueryParameter] int $page = 1, #[MapQueryParameter] array $filters = []): Response
     {
-        $user = $this->getUser();
-        $displayReviewsInAllLanguages = false;
-        if (null !== $user) {
-            $displayReviewsInAllLanguages = $this->getUser()->isDisplayReviewsInAllLanguages();
-        }
+        $preferredReviewLanguages = $reviewLanguagePreferenceService->resolve($request);
 
         $pagination = $paginator->paginate(
-            $riddenCoasterRepository->getCoasterReviews($coaster, $request->getLocale(), $displayReviewsInAllLanguages, $filters),
+            $riddenCoasterRepository->getCoasterReviews($coaster, $request->getLocale(), true, $filters),
             $page,
             25
         );
@@ -179,7 +176,7 @@ class CoasterController extends BaseController
             [
                 'reviews' => $pagination,
                 'coaster' => $coaster,
-                'displayReviewsInAllLanguages' => $displayReviewsInAllLanguages,
+                'preferredReviewLanguages' => $preferredReviewLanguages,
                 'filters' => $filters,
             ]
         );

--- a/src/Controller/CoasterController.php
+++ b/src/Controller/CoasterController.php
@@ -166,7 +166,7 @@ class CoasterController extends BaseController
         $preferredReviewLanguages = $reviewLanguagePreferenceService->resolve($request);
 
         $pagination = $paginator->paginate(
-            $riddenCoasterRepository->getCoasterReviews($coaster, $request->getLocale(), true, $filters),
+            $riddenCoasterRepository->getCoasterReviews($coaster, $preferredReviewLanguages[0] ?? $request->getLocale(), false, $filters),
             $page,
             25
         );

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -8,6 +8,7 @@ use App\Form\Type\ContactType;
 use App\Repository\ImageRepository;
 use App\Repository\RiddenCoasterRepository;
 use App\Service\LocalePreferenceService;
+use App\Service\ReviewLanguagePreferenceService;
 use App\Service\StatService;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
@@ -50,12 +51,11 @@ class DefaultController extends BaseController
      * @throws \Exception
      */
     #[Route(path: '/', name: 'default_index', methods: ['GET'])]
-    public function index(Request $request, StatService $statService, RiddenCoasterRepository $riddenCoasterRepository, ImageRepository $imageRepository): Response
+    public function index(Request $request, StatService $statService, RiddenCoasterRepository $riddenCoasterRepository, ImageRepository $imageRepository, ReviewLanguagePreferenceService $reviewLanguagePreferenceService): Response
     {
-        $displayReviewsInAllLanguages = false;
+        $preferredReviewLanguages = $reviewLanguagePreferenceService->resolve($request);
         $missingImages = [];
         if ($user = $this->getUser()) {
-            $displayReviewsInAllLanguages = $this->getUser()->isDisplayReviewsInAllLanguages();
             $missingImages = $riddenCoasterRepository->findCoastersWithNoImage($user);
         }
 
@@ -63,9 +63,9 @@ class DefaultController extends BaseController
             'ratingFeed' => $riddenCoasterRepository->getLatestRatings(6),
             'image' => $imageRepository->findLatestLikedImage(),
             'stats' => $statService->getIndexStats(),
-            'reviews' => $riddenCoasterRepository->getLatestReviews($request->getLocale(), 3, $displayReviewsInAllLanguages),
+            'reviews' => $riddenCoasterRepository->getLatestReviews($request->getLocale(), 3, true),
             'missingImages' => $missingImages,
-            'displayReviewsInAllLanguages' => $displayReviewsInAllLanguages,
+            'preferredReviewLanguages' => $preferredReviewLanguages,
         ]);
     }
 

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -63,7 +63,7 @@ class DefaultController extends BaseController
             'ratingFeed' => $riddenCoasterRepository->getLatestRatings(6),
             'image' => $imageRepository->findLatestLikedImage(),
             'stats' => $statService->getIndexStats(),
-            'reviews' => $riddenCoasterRepository->getLatestReviews($preferredReviewLanguages[0] ?? $request->getLocale(), 3, false),
+            'reviews' => $riddenCoasterRepository->getLatestReviews($preferredReviewLanguages, 3),
             'missingImages' => $missingImages,
             'preferredReviewLanguages' => $preferredReviewLanguages,
         ]);

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -63,7 +63,7 @@ class DefaultController extends BaseController
             'ratingFeed' => $riddenCoasterRepository->getLatestRatings(6),
             'image' => $imageRepository->findLatestLikedImage(),
             'stats' => $statService->getIndexStats(),
-            'reviews' => $riddenCoasterRepository->getLatestReviews($request->getLocale(), 3, true),
+            'reviews' => $riddenCoasterRepository->getLatestReviews($preferredReviewLanguages[0] ?? $request->getLocale(), 3, false),
             'missingImages' => $missingImages,
             'preferredReviewLanguages' => $preferredReviewLanguages,
         ]);

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use App\Form\Type\RegistrationFormType;
 use App\Notifier\CustomLoginLinkNotification;
 use App\Service\EmailValidationService;
+use App\Service\UnitsService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,7 +30,8 @@ class RegistrationController extends AbstractController
         EmailValidationService $emailValidator,
         RateLimiterFactory $registrationLimiter,
         NotifierInterface $notifier,
-        LoginLinkHandlerInterface $loginLinkHandler
+        LoginLinkHandlerInterface $loginLinkHandler,
+        UnitsService $unitsService
     ): Response {
         // Redirect if already logged in
         if ($this->getUser()) {
@@ -56,6 +58,7 @@ class RegistrationController extends AbstractController
             if ($emailValidator->isValidEmail($user->getEmail())) {
                 // Create user as enabled (no verification needed)
                 $user->setPreferredLocale($request->getLocale());
+                $user->setPreferredUnits($unitsService->guessUnitsFromRequest($request));
                 $ipAddress = $request->getClientIp();
                 if (null !== $ipAddress) {
                     $user->setIpAddress($ipAddress);

--- a/src/Controller/ReviewController.php
+++ b/src/Controller/ReviewController.php
@@ -8,6 +8,7 @@ use App\Entity\Coaster;
 use App\Entity\RiddenCoaster;
 use App\Form\Type\ReviewType;
 use App\Repository\RiddenCoasterRepository;
+use App\Service\ReviewLanguagePreferenceService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Knp\Component\Pager\PaginatorInterface;
@@ -30,17 +31,14 @@ class ReviewController extends BaseController
         Request $request,
         RiddenCoasterRepository $riddenCoasterRepository,
         PaginatorInterface $paginator,
+        ReviewLanguagePreferenceService $reviewLanguagePreferenceService,
         int $page = 1
     ): Response {
-        $user = $this->getUser();
-        $displayReviewsInAllLanguages = false;
-        if (null !== $user) {
-            $displayReviewsInAllLanguages = $this->getUser()->isDisplayReviewsInAllLanguages();
-        }
+        $preferredReviewLanguages = $reviewLanguagePreferenceService->resolve($request);
 
         try {
             $pagination = $paginator->paginate(
-                $riddenCoasterRepository->findAllReviews($request->getLocale(), $displayReviewsInAllLanguages),
+                $riddenCoasterRepository->findAllReviews($preferredReviewLanguages),
                 $page,
                 10
             );
@@ -50,7 +48,10 @@ class ReviewController extends BaseController
 
         return $this->render(
             'Review/list.html.twig',
-            ['reviews' => $pagination]
+            [
+                'reviews' => $pagination,
+                'preferredReviewLanguages' => $preferredReviewLanguages,
+            ]
         );
     }
 

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -11,6 +11,7 @@ use App\Repository\ImageRepository;
 use App\Repository\RiddenCoasterRepository;
 use App\Repository\TopRepository;
 use App\Repository\UserRepository;
+use App\Service\ReviewLanguagePreferenceService;
 use App\Service\StatService;
 use Doctrine\ORM\EntityManagerInterface;
 use Knp\Component\Pager\PaginatorInterface;
@@ -81,8 +82,10 @@ class UserController extends BaseController
     /** Show all user's reviews. */
     #[Route(path: '/{id}/reviews/{page}', name: 'user_reviews', requirements: ['page' => '\d+'], methods: ['GET'])]
     public function listReviews(
+        Request $request,
         RiddenCoasterRepository $riddenCoasterRepository,
         PaginatorInterface $paginator,
+        ReviewLanguagePreferenceService $reviewLanguagePreferenceService,
         User $user,
         int $page = 1
     ): Response {
@@ -110,6 +113,7 @@ class UserController extends BaseController
             [
                 'reviews' => $pagination,
                 'user' => $user,
+                'preferredReviewLanguages' => $reviewLanguagePreferenceService->resolve($request),
             ]
         );
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -141,7 +141,7 @@ class User implements UserInterface
     private string $preferredUnits = 'metric';
 
     /** @var array<string> */
-    #[ORM\Column(type: Types::JSON)]
+    #[ORM\Column(type: Types::JSON, options: ['default' => '[]'])]
     private array $preferredReviewLanguages = [];
 
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -140,8 +140,9 @@ class User implements UserInterface
     #[ORM\Column(type: Types::STRING, length: 20, nullable: false, options: ['default' => 'metric'])]
     private string $preferredUnits = 'metric';
 
-    #[ORM\Column(type: Types::BOOLEAN, nullable: false, options: ['default' => 0])]
-    private bool $displayReviewsInAllLanguages = false;
+    /** @var array<string> */
+    #[ORM\Column(type: Types::JSON)]
+    private array $preferredReviewLanguages = [];
 
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $deletedAt = null;
@@ -652,14 +653,30 @@ class User implements UserInterface
         return null;
     }
 
-    public function isDisplayReviewsInAllLanguages(): bool
+    /** @return array<string> */
+    public function getPreferredReviewLanguages(): array
     {
-        return $this->displayReviewsInAllLanguages;
+        return $this->preferredReviewLanguages;
     }
 
+    /** @param array<string> $preferredReviewLanguages */
+    public function setPreferredReviewLanguages(array $preferredReviewLanguages): static
+    {
+        $this->preferredReviewLanguages = $preferredReviewLanguages;
+
+        return $this;
+    }
+
+    /** @deprecated Use getPreferredReviewLanguages() with ReviewLanguagePreferenceService instead. True only when every supported locale is present — the old boolean's actual meaning. Still called by ProfileSettingsForm.php's binding and existing controllers. */
+    public function isDisplayReviewsInAllLanguages(): bool
+    {
+        return [] === array_diff(['en', 'fr', 'es', 'de'], $this->preferredReviewLanguages);
+    }
+
+    /** @deprecated use setPreferredReviewLanguages() instead */
     public function setDisplayReviewsInAllLanguages(bool $displayReviewsInAllLanguages): static
     {
-        $this->displayReviewsInAllLanguages = $displayReviewsInAllLanguages;
+        $this->preferredReviewLanguages = $displayReviewsInAllLanguages ? ['en', 'fr', 'es', 'de'] : [];
 
         return $this;
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -667,12 +667,6 @@ class User implements UserInterface
         return $this;
     }
 
-    /** @deprecated Use getPreferredReviewLanguages() with ReviewLanguagePreferenceService instead. True only when every supported locale is present — the old boolean's actual meaning. Still called by ProfileSettingsForm.php's binding and existing controllers. */
-    public function isDisplayReviewsInAllLanguages(): bool
-    {
-        return [] === array_diff(['en', 'fr', 'es', 'de'], $this->preferredReviewLanguages);
-    }
-
     public function getDeletedAt(): ?\DateTimeInterface
     {
         return $this->deletedAt;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -673,14 +673,6 @@ class User implements UserInterface
         return [] === array_diff(['en', 'fr', 'es', 'de'], $this->preferredReviewLanguages);
     }
 
-    /** @deprecated use setPreferredReviewLanguages() instead */
-    public function setDisplayReviewsInAllLanguages(bool $displayReviewsInAllLanguages): static
-    {
-        $this->preferredReviewLanguages = $displayReviewsInAllLanguages ? ['en', 'fr', 'es', 'de'] : [];
-
-        return $this;
-    }
-
     public function getDeletedAt(): ?\DateTimeInterface
     {
         return $this->deletedAt;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -137,8 +137,8 @@ class User implements UserInterface
     #[ORM\Column(type: Types::STRING, length: 39, nullable: true)]
     private ?string $ipAddress = null;
 
-    #[ORM\Column(type: Types::BOOLEAN, nullable: false, options: ['default' => 0])]
-    private bool $imperial = false;
+    #[ORM\Column(type: Types::STRING, length: 20, nullable: false, options: ['default' => 'metric'])]
+    private string $preferredUnits = 'metric';
 
     #[ORM\Column(type: Types::BOOLEAN, nullable: false, options: ['default' => 0])]
     private bool $displayReviewsInAllLanguages = false;
@@ -628,14 +628,14 @@ class User implements UserInterface
         return $this;
     }
 
-    public function isImperial(): bool
+    public function getPreferredUnits(): string
     {
-        return $this->imperial;
+        return $this->preferredUnits;
     }
 
-    public function setImperial(bool $imperial): static
+    public function setPreferredUnits(string $preferredUnits): static
     {
-        $this->imperial = $imperial;
+        $this->preferredUnits = $preferredUnits;
 
         return $this;
     }

--- a/src/EventSubscriber/LocaleCookieSubscriber.php
+++ b/src/EventSubscriber/LocaleCookieSubscriber.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\EventSubscriber;
 
+use App\Entity\User;
 use App\Service\LocalePreferenceService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -12,16 +15,22 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * Persists the visitor's locale choice: any request carrying a ?setLocale
- * query param (set by the navbar switcher link) gets the locale cookie
- * written on its response. setLocale is a presence flag, not a value --
- * the cookie value comes from the request's already-resolved locale (the
- * URL's _locale segment), so there's no separate value that could ever
- * disagree with the page actually being viewed. No redirect is involved
- * either -- the switcher links directly to the destination page, so
- * there is no redirect target to validate.
+ * query param (set by the account-menu language row) applies it. Logged
+ * in, the choice writes straight to the profile -- no cookie is ever
+ * written or read for an authenticated visitor, in either direction.
+ * Anonymous, it sets the locale cookie exactly as before. setLocale is a
+ * presence flag, not a value -- the target locale is always the request's
+ * own already-resolved locale (the URL's _locale segment), never a
+ * separate value that could disagree with the page being viewed.
  */
 class LocaleCookieSubscriber implements EventSubscriberInterface
 {
+    public function __construct(
+        private readonly Security $security,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
     public static function getSubscribedEvents(): array
     {
         return [
@@ -40,15 +49,23 @@ class LocaleCookieSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $locale = $request->getLocale();
+        $user = $this->security->getUser();
+
+        if ($user instanceof User) {
+            if ($user->getPreferredLocale() !== $locale) {
+                $user->setPreferredLocale($locale);
+                $this->em->flush();
+            }
+
+            return;
+        }
+
         $event->getResponse()->headers->setCookie(Cookie::create(
             name: LocalePreferenceService::COOKIE_NAME,
-            value: $request->getLocale(),
+            value: $locale,
             expire: strtotime('+1 year'),
             path: '/',
-            // Hardcoded true, matching security.yaml's remember-me cookie
-            // convention -- $request->isSecure() would return false behind
-            // a TLS-terminating proxy unless trusted_proxies is configured,
-            // which it isn't in any committed config here.
             secure: true,
             httpOnly: true,
             sameSite: Cookie::SAMESITE_LAX,

--- a/src/EventSubscriber/UnitsCookieSubscriber.php
+++ b/src/EventSubscriber/UnitsCookieSubscriber.php
@@ -23,8 +23,6 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class UnitsCookieSubscriber implements EventSubscriberInterface
 {
-    private const VALID_UNITS = ['metric', 'imperial'];
-
     public function __construct(
         private readonly Security $security,
         private readonly EntityManagerInterface $em,
@@ -45,7 +43,7 @@ class UnitsCookieSubscriber implements EventSubscriberInterface
         }
 
         $units = $event->getRequest()->query->get('setUnits');
-        if (!\is_string($units) || !\in_array($units, self::VALID_UNITS, true)) {
+        if (!\is_string($units) || !\in_array($units, UnitsService::VALID_UNITS, true)) {
             return;
         }
 

--- a/src/EventSubscriber/UnitsCookieSubscriber.php
+++ b/src/EventSubscriber/UnitsCookieSubscriber.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use App\Entity\User;
+use App\Service\UnitsService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Persists the visitor's units choice, symmetric to
+ * LocaleCookieSubscriber. Unlike locale, no URL segment already encodes
+ * the target value, so ?setUnits= carries an explicit value (metric |
+ * imperial) instead of being a bare presence flag -- validated against
+ * that two-item allow-list before being trusted. Logged in, it writes
+ * straight to the profile; anonymous, it sets the units cookie.
+ */
+class UnitsCookieSubscriber implements EventSubscriberInterface
+{
+    private const VALID_UNITS = ['metric', 'imperial'];
+
+    public function __construct(
+        private readonly Security $security,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        ];
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $units = $event->getRequest()->query->get('setUnits');
+        if (!\is_string($units) || !\in_array($units, self::VALID_UNITS, true)) {
+            return;
+        }
+
+        $user = $this->security->getUser();
+
+        if ($user instanceof User) {
+            if ($user->getPreferredUnits() !== $units) {
+                $user->setPreferredUnits($units);
+                $this->em->flush();
+            }
+
+            return;
+        }
+
+        $event->getResponse()->headers->setCookie(Cookie::create(
+            name: UnitsService::COOKIE_NAME,
+            value: $units,
+            expire: strtotime('+1 year'),
+            path: '/',
+            secure: true,
+            httpOnly: true,
+            sameSite: Cookie::SAMESITE_LAX,
+        ));
+    }
+}

--- a/src/Form/Type/ProfileSettingsForm.php
+++ b/src/Form/Type/ProfileSettingsForm.php
@@ -133,10 +133,10 @@ class ProfileSettingsForm extends AbstractType
                 ->orderBy('p.name', 'ASC'),
         ]);
 
-        $builder->add('imperial', ChoiceType::class, [
+        $builder->add('preferredUnits', ChoiceType::class, [
             'choices' => [
-                'profile.settings.preferences.units.metric' => false,
-                'profile.settings.preferences.units.imperial' => true,
+                'profile.settings.preferences.units.metric' => 'metric',
+                'profile.settings.preferences.units.imperial' => 'imperial',
             ],
             'label' => 'profile.settings.preferences.units.label',
             'attr' => ['class' => 'form-control'],

--- a/src/Form/Type/ProfileSettingsForm.php
+++ b/src/Form/Type/ProfileSettingsForm.php
@@ -142,9 +142,14 @@ class ProfileSettingsForm extends AbstractType
             'attr' => ['class' => 'form-control'],
         ]);
 
-        $builder->add('displayReviewsInAllLanguages', CheckboxType::class, [
+        $builder->add('preferredReviewLanguages', ChoiceType::class, [
+            'choices' => array_combine($locales, $locales),
+            'choice_label' => static fn ($value) => $value,
+            'multiple' => true,
+            'expanded' => true,
             'required' => false,
-            'label' => 'profile.settings.preferences.displayReviewsInAllLanguages.label',
+            'label' => 'profile.settings.preferences.preferredReviewLanguages.label',
+            'help' => 'profile.settings.preferences.preferredReviewLanguages.help',
         ]);
 
         $builder->add('addTodayDateWhenRating', CheckboxType::class, [

--- a/src/Form/Type/ProfileSettingsForm.php
+++ b/src/Form/Type/ProfileSettingsForm.php
@@ -149,7 +149,6 @@ class ProfileSettingsForm extends AbstractType
             'expanded' => true,
             'required' => false,
             'label' => 'profile.settings.preferences.preferredReviewLanguages.label',
-            'help' => 'profile.settings.preferences.preferredReviewLanguages.help',
         ]);
 
         $builder->add('addTodayDateWhenRating', CheckboxType::class, [

--- a/src/Repository/RiddenCoasterRepository.php
+++ b/src/Repository/RiddenCoasterRepository.php
@@ -11,6 +11,7 @@ use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
+use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -121,14 +122,14 @@ class RiddenCoasterRepository extends ServiceEntityRepository
     /**
      * Get ratings for a specific coaster.
      *
+     * @param array<string>        $preferredReviewLanguages
      * @param array<string, mixed> $filters
      *
      * @return array<int, RiddenCoaster>
      */
     public function getCoasterReviews(
         Coaster $coaster,
-        string $locale = 'en',
-        bool $displayReviewsInAllLanguages = true,
+        array $preferredReviewLanguages = ['en'],
         array $filters = []
     ): array {
         // add joins to avoid multiple subqueries
@@ -136,7 +137,7 @@ class RiddenCoasterRepository extends ServiceEntityRepository
             ->createQueryBuilder()
             ->select('r', 'p', 'c', 'u', 'up', 'co')
             ->addSelect(
-                'CASE WHEN (r.language = :locale OR :displayReviewsInAllLanguages = 1) AND r.review IS NOT NULL THEN 0 ELSE 1 END AS HIDDEN languagePriority'
+                'CASE WHEN r.language IN (:preferredReviewLanguages) AND r.review IS NOT NULL THEN 0 ELSE 1 END AS HIDDEN languagePriority'
             )
             ->from(RiddenCoaster::class, 'r')
             ->innerJoin('r.user', 'u')
@@ -147,8 +148,7 @@ class RiddenCoasterRepository extends ServiceEntityRepository
             ->where('r.coaster = :coasterId')
             ->andWhere('u.enabled = 1')
             ->setParameter('coasterId', $coaster->getId())
-            ->setParameter('locale', $locale)
-            ->setParameter('displayReviewsInAllLanguages', $displayReviewsInAllLanguages);
+            ->setParameter('preferredReviewLanguages', $preferredReviewLanguages);
 
         $this->applyFilters($query, $filters);
 
@@ -231,15 +231,17 @@ class RiddenCoasterRepository extends ServiceEntityRepository
     /**
      * Get latest text reviews ordered by language.
      *
+     * @param array<string> $preferredReviewLanguages
+     *
      * @return array<int, RiddenCoaster>
      */
-    public function getLatestReviews(string $locale = 'en', int $limit = 3, bool $displayReviewsInAllLanguages = false): array
+    public function getLatestReviews(array $preferredReviewLanguages = ['en'], int $limit = 3): array
     {
         $query = $this->getEntityManager()
             ->createQueryBuilder()
             ->select('r')
             ->addSelect(
-                'CASE WHEN (r.language = :locale OR :displayReviewsInAllLanguages = 1) AND r.review IS NOT NULL THEN 0 ELSE 1 END AS HIDDEN languagePriority'
+                'CASE WHEN r.language IN (:preferredReviewLanguages) AND r.review IS NOT NULL THEN 0 ELSE 1 END AS HIDDEN languagePriority'
             )
             ->addSelect('u')
             ->from(RiddenCoaster::class, 'r')
@@ -249,8 +251,7 @@ class RiddenCoasterRepository extends ServiceEntityRepository
             ->orderBy('languagePriority', 'asc')
             ->addOrderBy('r.updatedAt', 'desc')
             ->setMaxResults($limit)
-            ->setParameter('locale', $locale)
-            ->setParameter('displayReviewsInAllLanguages', $displayReviewsInAllLanguages)
+            ->setParameter('preferredReviewLanguages', $preferredReviewLanguages)
             ->getQuery();
 
         $query->enableResultCache(300);
@@ -313,13 +314,17 @@ class RiddenCoasterRepository extends ServiceEntityRepository
     }
 
     /**
-     * Get all reviews ordered by language.
+     * Get reviews with text in one of the given languages. Unlike the other
+     * review listings, this feed excludes non-matching reviews entirely
+     * (rather than keeping the row and hiding its text) and applies no
+     * language-based sort priority -- it's a dedicated reading feed, so a
+     * rating-only row with its text hidden would just be dead weight.
      *
-     * @return array|mixed
+     * @param array<string> $preferredReviewLanguages
      *
-     * @throws NonUniqueResultException
+     * @return Query<mixed, mixed>
      */
-    public function findAllReviews(string $locale = 'en', bool $displayReviewsInAllLanguages = false)
+    public function findAllReviews(array $preferredReviewLanguages): Query
     {
         $count = $this->getEntityManager()
             ->createQueryBuilder()
@@ -327,24 +332,22 @@ class RiddenCoasterRepository extends ServiceEntityRepository
             ->from(RiddenCoaster::class, 'r')
             ->innerJoin('r.user', 'u')
             ->where('r.review is not null')
+            ->andWhere('r.language IN (:preferredReviewLanguages)')
             ->andWhere('u.enabled = 1')
+            ->setParameter('preferredReviewLanguages', $preferredReviewLanguages)
             ->getQuery()
             ->getSingleScalarResult();
 
         return $this->getEntityManager()
             ->createQueryBuilder()
             ->select('r, u')
-            ->addSelect(
-                'CASE WHEN (r.language = :locale OR :displayReviewsInAllLanguages = 1) AND r.review IS NOT NULL THEN 0 ELSE 1 END AS HIDDEN languagePriority'
-            )
             ->from(RiddenCoaster::class, 'r')
             ->innerJoin('r.user', 'u')
             ->where('r.review is not null')
+            ->andWhere('r.language IN (:preferredReviewLanguages)')
             ->andWhere('u.enabled = 1')
-            ->orderBy('languagePriority', 'asc')
-            ->addOrderBy('r.updatedAt', 'desc')
-            ->setParameter('locale', $locale)
-            ->setParameter('displayReviewsInAllLanguages', $displayReviewsInAllLanguages)
+            ->orderBy('r.updatedAt', 'desc')
+            ->setParameter('preferredReviewLanguages', $preferredReviewLanguages)
             ->getQuery()
             ->setHint('knp_paginator.count', $count);
     }

--- a/src/Security/GoogleAuthenticator.php
+++ b/src/Security/GoogleAuthenticator.php
@@ -113,7 +113,7 @@ class GoogleAuthenticator extends OAuth2Authenticator implements AuthenticationE
 
         if (!$user instanceof User) {
             $user = new User();
-            $user->setPreferredLocale($request->getSession()->get('locale_at_login', 'en'));
+            $user->setPreferredLocale($request->getSession()->get('locale_at_login', $request->getLocale()));
             $user->setPreferredUnits($this->unitsService->guessUnitsFromRequest($request));
             $user->setIpAddress($request->getClientIp());
             $user->setEnabled(true);

--- a/src/Security/GoogleAuthenticator.php
+++ b/src/Security/GoogleAuthenticator.php
@@ -6,6 +6,7 @@ namespace App\Security;
 
 use App\Entity\User;
 use App\Service\ProfilePictureManager;
+use App\Service\UnitsService;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
@@ -37,7 +38,8 @@ class GoogleAuthenticator extends OAuth2Authenticator implements AuthenticationE
         private readonly EntityManagerInterface $em,
         private readonly ProfilePictureManager $profilePictureManager,
         private readonly RouterInterface $router,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly UnitsService $unitsService
     ) {
     }
 
@@ -112,6 +114,7 @@ class GoogleAuthenticator extends OAuth2Authenticator implements AuthenticationE
         if (!$user instanceof User) {
             $user = new User();
             $user->setPreferredLocale($request->getSession()->get('locale_at_login', 'en'));
+            $user->setPreferredUnits($this->unitsService->guessUnitsFromRequest($request));
             $user->setIpAddress($request->getClientIp());
             $user->setEnabled(true);
         }

--- a/src/Service/ReviewLanguagePreferenceService.php
+++ b/src/Service/ReviewLanguagePreferenceService.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Resolves which review languages a viewer wants to see written text for.
+ * An empty preference (the default, for every anonymous visitor and every
+ * logged-in user who hasn't customized it) means "only my own language" --
+ * preferredLocale when logged in, the current page's locale otherwise.
+ */
+class ReviewLanguagePreferenceService
+{
+    public function __construct(private readonly Security $security)
+    {
+    }
+
+    /** @return array<string> */
+    public function resolve(Request $request): array
+    {
+        $user = $this->security->getUser();
+
+        if ($user instanceof User) {
+            $preferred = $user->getPreferredReviewLanguages();
+
+            return [] === $preferred ? [$user->getPreferredLocale()] : $preferred;
+        }
+
+        return [$request->getLocale()];
+    }
+}

--- a/src/Service/UnitsService.php
+++ b/src/Service/UnitsService.php
@@ -17,9 +17,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * parameter (so the very page carrying the switcher link already reflects
  * the new choice, before UnitsCookieSubscriber has persisted it for future
  * requests) > logged-in user's saved profile preference > cookie (anonymous
- * visitors) > Cloudflare's CF-IPCountry header > browser's Accept-Language
- * region preferences > metric default. See guessUnitsFromRequest() for the
- * CF-IPCountry and Accept-Language logic.
+ * visitors) > browser's Accept-Language region preferences > metric default.
+ * See guessUnitsFromRequest() for the Accept-Language logic.
  *
  * Exposed to Twig via the `units` global (config/packages/twig.yaml),
  * called directly as an object (units.metersOrFeet(...)), not as
@@ -31,12 +30,6 @@ class UnitsService
 
     /** Allow-listed values for the units preference, shared with UnitsCookieSubscriber. */
     public const VALID_UNITS = ['metric', 'imperial'];
-
-    /** ISO 3166-1 alpha-2 country codes (from Cloudflare's CF-IPCountry header) that use imperial units. */
-    private const IMPERIAL_COUNTRIES = ['US', 'GB'];
-
-    /** Non-country CF-IPCountry placeholder values -- unknown country ('XX'), Tor exit node ('T1'), or absent (''). Treated as no signal at all. */
-    private const NON_COUNTRY_CF_CODES = ['XX', 'T1', ''];
 
     /** Browser locale regions that default to imperial when no user preference exists. */
     private const IMPERIAL_LANGUAGE_REGIONS = ['en_US', 'en_GB'];
@@ -114,25 +107,10 @@ class UnitsService
     }
 
     /**
-     * Guess metric/imperial from the request's CF-IPCountry header or
-     * Accept-Language preferences.
+     * Guess metric/imperial from the request's Accept-Language preferences.
      *
-     * **Primary signal: CF-IPCountry.** If Cloudflare's CF-IPCountry header
-     * is present with a real country code, it takes absolute priority:
-     * checks the ISO 3166-1 alpha-2 country code against our
-     * IMPERIAL_COUNTRIES list (['US', 'GB']). Returns 'imperial' if matched,
-     * 'metric' otherwise. Accept-Language is never consulted if this header
-     * carries a real country.
-     *
-     * Cloudflare also sends non-country placeholder values -- `XX` for an
-     * unknown country and `T1` for Tor exit nodes -- which are treated as
-     * absent (fall through to Accept-Language) rather than as a real,
-     * non-matching country (which would force 'metric' and override a
-     * legitimate Accept-Language signal).
-     *
-     * **Fallback: Accept-Language region preferences.** If CF-IPCountry is
-     * absent, walks the browser's language preferences in order, stopping at
-     * the first entry that carries a *region* (e.g. "en-US" vs "en-GB") —
+     * Walks the browser's language preferences in order, stopping at the
+     * first entry that carries a *region* (e.g. "en-US" vs "en-GB") —
      * language alone isn't a reliable signal, since English is also the
      * majority language in fully metric countries (Canada, Australia); see
      * GitHub issue #108. The UK is a deliberate exception: despite officially
@@ -147,11 +125,6 @@ class UnitsService
      */
     public function guessUnitsFromRequest(Request $request): string
     {
-        $cfCountry = $request->headers->get('CF-IPCountry');
-        if (\is_string($cfCountry) && !\in_array(strtoupper($cfCountry), self::NON_COUNTRY_CF_CODES, true)) {
-            return \in_array(strtoupper($cfCountry), self::IMPERIAL_COUNTRIES, true) ? 'imperial' : 'metric';
-        }
-
         foreach ($request->getLanguages() as $language) {
             if (str_contains($language, '_')) {
                 return \in_array($language, self::IMPERIAL_LANGUAGE_REGIONS, true) ? 'imperial' : 'metric';

--- a/src/Service/UnitsService.php
+++ b/src/Service/UnitsService.php
@@ -24,6 +24,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class UnitsService
 {
+    public const COOKIE_NAME = 'units';
+
     /** ISO 3166-1 alpha-2 country codes (from Cloudflare's CF-IPCountry header) that use imperial units. */
     private const IMPERIAL_COUNTRIES = ['US', 'GB'];
 
@@ -46,7 +48,17 @@ class UnitsService
             return 'imperial' === $user->getPreferredUnits();
         }
 
-        return $this->guessImperialFromBrowserLocale();
+        $request = $this->requestStack->getCurrentRequest();
+        if (!$request) {
+            return false;
+        }
+
+        $cookieUnits = $request->cookies->get(self::COOKIE_NAME);
+        if (\is_string($cookieUnits) && \in_array($cookieUnits, ['metric', 'imperial'], true)) {
+            return 'imperial' === $cookieUnits;
+        }
+
+        return 'imperial' === $this->guessUnitsFromRequest($request);
     }
 
     public function metersOrFeet(int $value): string
@@ -124,20 +136,5 @@ class UnitsService
         }
 
         return 'metric';
-    }
-
-    /**
-     * Thin delegate to guessUnitsFromRequest() for isImperial() when
-     * RequestStack has a current request. Used only when no logged-in user
-     * is present. See guessUnitsFromRequest() for the detailed algorithm.
-     */
-    private function guessImperialFromBrowserLocale(): bool
-    {
-        $request = $this->requestStack->getCurrentRequest();
-        if (!$request) {
-            return false;
-        }
-
-        return 'imperial' === $this->guessUnitsFromRequest($request);
     }
 }

--- a/src/Service/UnitsService.php
+++ b/src/Service/UnitsService.php
@@ -6,6 +6,7 @@ namespace App\Service;
 
 use App\Entity\User;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -29,6 +30,9 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class UnitsService
 {
+    /** ISO 3166-1 alpha-2 country codes (from Cloudflare's CF-IPCountry header) that use imperial units. */
+    private const IMPERIAL_COUNTRIES = ['US', 'GB'];
+
     /** Browser locale regions that default to imperial when no user preference exists. */
     private const IMPERIAL_LANGUAGE_REGIONS = ['en_US', 'en_GB'];
 
@@ -87,6 +91,22 @@ class UnitsService
         return (int) round($km / self::KM_PER_MILE);
     }
 
+    public function guessUnitsFromRequest(Request $request): string
+    {
+        $cfCountry = $request->headers->get('CF-IPCountry');
+        if (\is_string($cfCountry)) {
+            return \in_array(strtoupper($cfCountry), self::IMPERIAL_COUNTRIES, true) ? 'imperial' : 'metric';
+        }
+
+        foreach ($request->getLanguages() as $language) {
+            if (str_contains($language, '_')) {
+                return \in_array($language, self::IMPERIAL_LANGUAGE_REGIONS, true) ? 'imperial' : 'metric';
+            }
+        }
+
+        return 'metric';
+    }
+
     /**
      * Walks the browser's language preferences in order and stops at the
      * first one that carries a region -- that region decides, imperial or
@@ -106,12 +126,6 @@ class UnitsService
             return false;
         }
 
-        foreach ($request->getLanguages() as $language) {
-            if (str_contains($language, '_')) {
-                return \in_array($language, self::IMPERIAL_LANGUAGE_REGIONS, true);
-            }
-        }
-
-        return false;
+        return 'imperial' === $this->guessUnitsFromRequest($request);
     }
 }

--- a/src/Service/UnitsService.php
+++ b/src/Service/UnitsService.php
@@ -13,16 +13,10 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * Resolves the visitor's metric/imperial preference and converts
  * height/speed/distance accordingly.
  *
- * Precedence: a logged-in user's saved profile preference, then a guess
- * from the browser's Accept-Language preferences, walked in order for the
- * first entry that carries a *region* (e.g. "en-US" vs "en-GB") — language
- * alone isn't a reliable signal, since English is also the majority
- * language in fully metric countries (Canada, Australia); see GitHub
- * issue #108. The UK is a deliberate exception: despite officially
- * adopting metric, road distances and speed limits stay legally imperial
- * (miles, mph) there — exactly the units this service converts — so
- * en_GB is grouped with en_US rather than with the fully metric English
- * regions.
+ * Precedence: logged-in user's saved profile preference > Cloudflare's
+ * CF-IPCountry header > browser's Accept-Language region preferences >
+ * metric default. See guessUnitsFromRequest() for the CF-IPCountry and
+ * Accept-Language logic.
  *
  * Exposed to Twig via the `units` global (config/packages/twig.yaml),
  * called directly as an object (units.metersOrFeet(...)), not as
@@ -91,6 +85,31 @@ class UnitsService
         return (int) round($km / self::KM_PER_MILE);
     }
 
+    /**
+     * Guess metric/imperial from the request's CF-IPCountry header or
+     * Accept-Language preferences.
+     *
+     * **Primary signal: CF-IPCountry.** If Cloudflare's CF-IPCountry header
+     * is present, it takes absolute priority: checks the ISO 3166-1 alpha-2
+     * country code against our IMPERIAL_COUNTRIES list (['US', 'GB']).
+     * Returns 'imperial' if matched, 'metric' otherwise. Accept-Language is
+     * never consulted if this header exists.
+     *
+     * **Fallback: Accept-Language region preferences.** If CF-IPCountry is
+     * absent, walks the browser's language preferences in order, stopping at
+     * the first entry that carries a *region* (e.g. "en-US" vs "en-GB") —
+     * language alone isn't a reliable signal, since English is also the
+     * majority language in fully metric countries (Canada, Australia); see
+     * GitHub issue #108. The UK is a deliberate exception: despite officially
+     * adopting metric, road distances and speed limits stay legally imperial
+     * (miles, mph) there — exactly the units this service converts — so
+     * en_GB is grouped with en_US rather than with the fully metric English
+     * regions. No region found anywhere defaults to 'metric'.
+     *
+     * Request::getLanguages() parses and caches the Accept-Language header
+     * once per request, and the list is at most a handful of entries, so
+     * this is a negligible cost to pay on every request.
+     */
     public function guessUnitsFromRequest(Request $request): string
     {
         $cfCountry = $request->headers->get('CF-IPCountry');
@@ -108,16 +127,9 @@ class UnitsService
     }
 
     /**
-     * Walks the browser's language preferences in order and stops at the
-     * first one that carries a region -- that region decides, imperial or
-     * not. Bare, region-less languages (e.g. plain "en") are skipped: they
-     * can't disambiguate anything on their own, since English is the
-     * majority language in both imperial (US, UK) and metric (Canada,
-     * Australia...) countries. No region found anywhere defaults to
-     * metric. Request::getLanguages() parses and caches the
-     * Accept-Language header once per request, and the list is at most a
-     * handful of entries, so this is a negligible cost to pay on every
-     * request.
+     * Thin delegate to guessUnitsFromRequest() for isImperial() when
+     * RequestStack has a current request. Used only when no logged-in user
+     * is present. See guessUnitsFromRequest() for the detailed algorithm.
      */
     private function guessImperialFromBrowserLocale(): bool
     {

--- a/src/Service/UnitsService.php
+++ b/src/Service/UnitsService.php
@@ -43,10 +43,9 @@ class UnitsService
 
     public function isImperial(): bool
     {
-        /** @var User|null $user */
         $user = $this->security->getUser();
-        if ($user) {
-            return $user->isImperial();
+        if ($user instanceof User) {
+            return 'imperial' === $user->getPreferredUnits();
         }
 
         return $this->guessImperialFromBrowserLocale();

--- a/src/Service/UnitsService.php
+++ b/src/Service/UnitsService.php
@@ -13,10 +13,13 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * Resolves the visitor's metric/imperial preference and converts
  * height/speed/distance accordingly.
  *
- * Precedence: logged-in user's saved profile preference > Cloudflare's
- * CF-IPCountry header > browser's Accept-Language region preferences >
- * metric default. See guessUnitsFromRequest() for the CF-IPCountry and
- * Accept-Language logic.
+ * Precedence: the current request's own validated `?setUnits=` query
+ * parameter (so the very page carrying the switcher link already reflects
+ * the new choice, before UnitsCookieSubscriber has persisted it for future
+ * requests) > logged-in user's saved profile preference > cookie (anonymous
+ * visitors) > Cloudflare's CF-IPCountry header > browser's Accept-Language
+ * region preferences > metric default. See guessUnitsFromRequest() for the
+ * CF-IPCountry and Accept-Language logic.
  *
  * Exposed to Twig via the `units` global (config/packages/twig.yaml),
  * called directly as an object (units.metersOrFeet(...)), not as
@@ -26,8 +29,14 @@ class UnitsService
 {
     public const COOKIE_NAME = 'units';
 
+    /** Allow-listed values for the units preference, shared with UnitsCookieSubscriber. */
+    public const VALID_UNITS = ['metric', 'imperial'];
+
     /** ISO 3166-1 alpha-2 country codes (from Cloudflare's CF-IPCountry header) that use imperial units. */
     private const IMPERIAL_COUNTRIES = ['US', 'GB'];
+
+    /** Non-country CF-IPCountry placeholder values -- unknown country ('XX'), Tor exit node ('T1'), or absent (''). Treated as no signal at all. */
+    private const NON_COUNTRY_CF_CODES = ['XX', 'T1', ''];
 
     /** Browser locale regions that default to imperial when no user preference exists. */
     private const IMPERIAL_LANGUAGE_REGIONS = ['en_US', 'en_GB'];
@@ -43,18 +52,25 @@ class UnitsService
 
     public function isImperial(): bool
     {
+        $request = $this->requestStack->getCurrentRequest();
+        if ($request instanceof Request) {
+            $requestedUnits = $request->query->get('setUnits');
+            if (\is_string($requestedUnits) && \in_array($requestedUnits, self::VALID_UNITS, true)) {
+                return 'imperial' === $requestedUnits;
+            }
+        }
+
         $user = $this->security->getUser();
         if ($user instanceof User) {
             return 'imperial' === $user->getPreferredUnits();
         }
 
-        $request = $this->requestStack->getCurrentRequest();
-        if (!$request) {
+        if (!$request instanceof Request) {
             return false;
         }
 
         $cookieUnits = $request->cookies->get(self::COOKIE_NAME);
-        if (\is_string($cookieUnits) && \in_array($cookieUnits, ['metric', 'imperial'], true)) {
+        if (\is_string($cookieUnits) && \in_array($cookieUnits, self::VALID_UNITS, true)) {
             return 'imperial' === $cookieUnits;
         }
 
@@ -102,10 +118,17 @@ class UnitsService
      * Accept-Language preferences.
      *
      * **Primary signal: CF-IPCountry.** If Cloudflare's CF-IPCountry header
-     * is present, it takes absolute priority: checks the ISO 3166-1 alpha-2
-     * country code against our IMPERIAL_COUNTRIES list (['US', 'GB']).
-     * Returns 'imperial' if matched, 'metric' otherwise. Accept-Language is
-     * never consulted if this header exists.
+     * is present with a real country code, it takes absolute priority:
+     * checks the ISO 3166-1 alpha-2 country code against our
+     * IMPERIAL_COUNTRIES list (['US', 'GB']). Returns 'imperial' if matched,
+     * 'metric' otherwise. Accept-Language is never consulted if this header
+     * carries a real country.
+     *
+     * Cloudflare also sends non-country placeholder values -- `XX` for an
+     * unknown country and `T1` for Tor exit nodes -- which are treated as
+     * absent (fall through to Accept-Language) rather than as a real,
+     * non-matching country (which would force 'metric' and override a
+     * legitimate Accept-Language signal).
      *
      * **Fallback: Accept-Language region preferences.** If CF-IPCountry is
      * absent, walks the browser's language preferences in order, stopping at
@@ -125,7 +148,7 @@ class UnitsService
     public function guessUnitsFromRequest(Request $request): string
     {
         $cfCountry = $request->headers->get('CF-IPCountry');
-        if (\is_string($cfCountry)) {
+        if (\is_string($cfCountry) && !\in_array(strtoupper($cfCountry), self::NON_COUNTRY_CF_CODES, true)) {
             return \in_array(strtoupper($cfCountry), self::IMPERIAL_COUNTRIES, true) ? 'imperial' : 'metric';
         }
 

--- a/templates/Coaster/_review_panel.html.twig
+++ b/templates/Coaster/_review_panel.html.twig
@@ -57,7 +57,7 @@
                 <ul class="media-list media-list-bordered">
                     {%- for review in reviews -%}
                         <li>
-                            {% include 'Includes/_review_item.html.twig' with {'review': review, 'displayReviewsInAllLanguages': displayReviewsInAllLanguages} %}
+                            {% include 'Includes/_review_item.html.twig' with {'review': review, 'preferredReviewLanguages': preferredReviewLanguages} %}
                         </li>
                     {%- endfor -%}
                 </ul>

--- a/templates/Default/index.html.twig
+++ b/templates/Default/index.html.twig
@@ -147,7 +147,7 @@
                     </a>
                   </h6>
                 </div>
-                {% include 'Includes/_review_item.html.twig' with {'review': review, 'displayReviewsInAllLanguages': displayReviewsInAllLanguages} %}
+                {% include 'Includes/_review_item.html.twig' with {'review': review, 'preferredReviewLanguages': preferredReviewLanguages} %}
               </li>
             {% endfor %}
           </ul>

--- a/templates/Includes/_review_item.html.twig
+++ b/templates/Includes/_review_item.html.twig
@@ -38,7 +38,7 @@
       </p>
     {% endif %}
 
-    {% if review.review and (displayReviewsInAllLanguages or review.language == app.request.locale) %}
+    {% if review.review and review.language in preferredReviewLanguages %}
       {% if review.review|length > 150 %}
         <div class="review-content" data-review-actions-target="reviewContent" data-full-text="{{ review.review }}">
           <p class="review-short">{{ review.review|slice(0, 150) }}...

--- a/templates/Profile/settings.html.twig
+++ b/templates/Profile/settings.html.twig
@@ -79,9 +79,9 @@
                 </div>
 
                 <div class="form-group">
-                  {{ form_label(form.imperial) }}
-                  {{ form_widget(form.imperial) }}
-                  {{ form_errors(form.imperial) }}
+                  {{ form_label(form.preferredUnits) }}
+                  {{ form_widget(form.preferredUnits) }}
+                  {{ form_errors(form.preferredUnits) }}
                 </div>
 
                 <div class="form-group">

--- a/templates/Profile/settings.html.twig
+++ b/templates/Profile/settings.html.twig
@@ -90,8 +90,11 @@
                   {{ form_errors(form.homePark) }}
                 </div>
 
-                <div class="toggle-switch-form-group" data-controller="toggle-switch">
-                  {{ form_row(form.displayReviewsInAllLanguages, {'attr': {'class': 'toggle-input', 'data-toggle-switch-target': 'checkbox', 'data-action': 'toggle-switch#toggle'}}) }}
+                <div class="form-group">
+                  {{ form_label(form.preferredReviewLanguages) }}
+                  {{ form_widget(form.preferredReviewLanguages) }}
+                  <p class="help-block">{{ 'profile.settings.preferences.preferredReviewLanguages.help'|trans }}</p>
+                  {{ form_errors(form.preferredReviewLanguages) }}
                 </div>
 
                 <div class="toggle-switch-form-group" data-controller="toggle-switch">

--- a/templates/Review/list.html.twig
+++ b/templates/Review/list.html.twig
@@ -29,7 +29,7 @@
                     </a>
                   </h6>
                 </div>
-                {% include 'Includes/_review_item.html.twig' with {'review': review, 'preferredReviewLanguages': locales} %}
+                {% include 'Includes/_review_item.html.twig' with {'review': review, 'preferredReviewLanguages': preferredReviewLanguages} %}
               </li>
             {% endfor %}
           </ul>

--- a/templates/Review/list.html.twig
+++ b/templates/Review/list.html.twig
@@ -29,7 +29,7 @@
                     </a>
                   </h6>
                 </div>
-                {% include 'Includes/_review_item.html.twig' with {'review': review, 'displayReviewsInAllLanguages': true} %}
+                {% include 'Includes/_review_item.html.twig' with {'review': review, 'preferredReviewLanguages': ['en', 'fr', 'es', 'de']} %}
               </li>
             {% endfor %}
           </ul>

--- a/templates/Review/list.html.twig
+++ b/templates/Review/list.html.twig
@@ -29,7 +29,7 @@
                     </a>
                   </h6>
                 </div>
-                {% include 'Includes/_review_item.html.twig' with {'review': review, 'preferredReviewLanguages': ['en', 'fr', 'es', 'de']} %}
+                {% include 'Includes/_review_item.html.twig' with {'review': review, 'preferredReviewLanguages': locales} %}
               </li>
             {% endfor %}
           </ul>

--- a/templates/User/list_reviews.html.twig
+++ b/templates/User/list_reviews.html.twig
@@ -29,7 +29,7 @@
                     </a>
                   </h6>
                 </div>
-                {% include 'Includes/_review_item.html.twig' with {'review': review, 'preferredReviewLanguages': locales} %}
+                {% include 'Includes/_review_item.html.twig' with {'review': review, 'preferredReviewLanguages': preferredReviewLanguages} %}
               </li>
             {% endfor %}
           </ul>

--- a/templates/User/list_reviews.html.twig
+++ b/templates/User/list_reviews.html.twig
@@ -29,7 +29,7 @@
                     </a>
                   </h6>
                 </div>
-                {% include 'Includes/_review_item.html.twig' with {'review': review, 'displayReviewsInAllLanguages': true} %}
+                {% include 'Includes/_review_item.html.twig' with {'review': review, 'preferredReviewLanguages': ['en', 'fr', 'es', 'de']} %}
               </li>
             {% endfor %}
           </ul>

--- a/templates/User/list_reviews.html.twig
+++ b/templates/User/list_reviews.html.twig
@@ -29,7 +29,7 @@
                     </a>
                   </h6>
                 </div>
-                {% include 'Includes/_review_item.html.twig' with {'review': review, 'preferredReviewLanguages': ['en', 'fr', 'es', 'de']} %}
+                {% include 'Includes/_review_item.html.twig' with {'review': review, 'preferredReviewLanguages': locales} %}
               </li>
             {% endfor %}
           </ul>

--- a/templates/navbar.html.twig
+++ b/templates/navbar.html.twig
@@ -23,28 +23,6 @@
       <li class="navbar-text">
         <span id="editor-saved" class="label bg-success"></span>
       </li>
-      <!-- language switcher -->
-      {% if app.request.attributes.get('_route') %}
-        <li class="dropdown language-switch">
-          <a class="dropdown-toggle" data-toggle="dropdown">
-            {{ app.request.locale|trans }}
-            <span class="caret"></span>
-          </a>
-          <ul class="dropdown-menu">
-            {% set route = app.request.attributes.get('_route') %}
-            {% set route_params = app.request.attributes.get('_route_params') %}
-            {% set params = route_params|merge(app.request.query.all) %}
-            {% for locale in locales|filter(v => v != app.request.locale) %}
-              <li>
-                <a href="{{ path(route, params|merge({ _locale: locale, setLocale: 1 })) }}">
-                  {{ locale|trans }}
-                </a>
-              </li>
-            {% endfor %}
-          </ul>
-        </li>
-      {% endif %}
-      <!-- /language switcher -->
       <!-- notifications -->
       {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
         <li class="dropdown">
@@ -87,37 +65,72 @@
             <i class="caret"></i>
           </a>
 
-          <ul class="dropdown-menu dropdown-menu-right">
-            <li>
-              <a href="{{ path('profile') }}">{{ ux_icon('heroicons:user', {'class': 'w-6 h-6'}) }} {{ 'navbar.profile'|trans }}</a>
-            </li>
-            <li>
-              <a href="{{ path('profile_settings') }}">
-                {{ ux_icon('heroicons:cog-6-tooth', {'class': 'w-6 h-6'}) }} {{ 'navbar.settings'|trans }}
-              </a>
-            </li>
-            <li>
-              <a href="{{ path('profile_ratings') }}">
-                {{ ux_icon('heroicons:star', {'class': 'w-6 h-6'}) }} {{ 'navbar.rating'|trans }}
-              </a>
-            </li>
-            <li>
-              <a href="{{ path('user_tops', {'id': app.user.id}) }}">
-                {{ ux_icon('heroicons:clipboard', {'class': 'w-6 h-6'}) }} {{ 'navbar.tops'|trans }}
-              </a>
-            </li>
-            <li>
-              <a href="{{ path('map_user', {'id': app.user.id}) }}">
-                {{ ux_icon('heroicons:map-pin', {'class': 'w-6 h-6'}) }} {{ 'navbar.my_map'|trans }}
-              </a>
+          <ul class="dropdown-menu dropdown-menu-right account-menu">
+            <li class="account-menu-header">
+              {{ helper.profilePicture(app.user, 'img-circle img-xs') }}
+              <div>
+                <div class="account-menu-name">{{ app.user.firstname }}</div>
+                <a href="{{ path('profile') }}">{{ 'navbar.profile'|trans }}</a>
+              </div>
             </li>
             <li class="divider"></li>
-            <li><a href="{{ path('logout') }}">{{ ux_icon('heroicons:arrow-right-on-rectangle', {'class': 'w-6 h-6'}) }} {{ 'navbar.logout'|trans }}</a>
+            <li class="account-menu-row">
+              <span class="account-menu-row-label">
+                {{ ux_icon('heroicons:language', {'class': 'w-5 h-5'}) }}
+                {{ 'navbar.language'|trans }}
+              </span>
+              <span class="account-menu-row-value">Français {{ ux_icon('heroicons:chevron-right', {'class': 'w-4 h-4'}) }}</span>
+            </li>
+            <li class="account-menu-row">
+              <span class="account-menu-row-label">
+                {{ ux_icon('heroicons:scale', {'class': 'w-5 h-5'}) }}
+                {{ 'navbar.units'|trans }}
+              </span>
+              <span class="account-menu-row-value">Métrique {{ ux_icon('heroicons:chevron-right', {'class': 'w-4 h-4'}) }}</span>
+            </li>
+            <li class="divider"></li>
+            <li>
+              <a href="{{ path('profile_settings') }}">{{ ux_icon('heroicons:cog-6-tooth', {'class': 'w-5 h-5'}) }} {{ 'navbar.settings'|trans }}</a>
+            </li>
+            <li>
+              <a href="{{ path('profile_ratings') }}">{{ ux_icon('heroicons:star', {'class': 'w-5 h-5'}) }} {{ 'navbar.rating'|trans }}</a>
+            </li>
+            <li>
+              <a href="{{ path('user_tops', {'id': app.user.id}) }}">{{ ux_icon('heroicons:clipboard', {'class': 'w-5 h-5'}) }} {{ 'navbar.tops'|trans }}</a>
+            </li>
+            <li>
+              <a href="{{ path('map_user', {'id': app.user.id}) }}">{{ ux_icon('heroicons:map-pin', {'class': 'w-5 h-5'}) }} {{ 'navbar.my_map'|trans }}</a>
+            </li>
+            <li class="divider"></li>
+            <li>
+              <a href="{{ path('logout') }}">{{ ux_icon('heroicons:arrow-right-on-rectangle', {'class': 'w-5 h-5'}) }} {{ 'navbar.logout'|trans }}</a>
             </li>
           </ul>
         </li>
       {% else %}
-        <li><a href="{{ path('login') }}">{{ 'navbar.login'|trans }}</a></li>
+        <li class="dropdown account-menu-anon">
+          <a class="dropdown-toggle" data-toggle="dropdown">
+            {{ ux_icon('heroicons:user-circle', {'class': 'w-8 h-8'}) }}
+          </a>
+          <ul class="dropdown-menu dropdown-menu-right account-menu">
+            <li class="account-menu-row">
+              <span class="account-menu-row-label">
+                {{ ux_icon('heroicons:language', {'class': 'w-5 h-5'}) }}
+                {{ 'navbar.language'|trans }}
+              </span>
+              <span class="account-menu-row-value">Français {{ ux_icon('heroicons:chevron-right', {'class': 'w-4 h-4'}) }}</span>
+            </li>
+            <li class="account-menu-row">
+              <span class="account-menu-row-label">
+                {{ ux_icon('heroicons:scale', {'class': 'w-5 h-5'}) }}
+                {{ 'navbar.units'|trans }}
+              </span>
+              <span class="account-menu-row-value">Métrique {{ ux_icon('heroicons:chevron-right', {'class': 'w-4 h-4'}) }}</span>
+            </li>
+            <li class="divider"></li>
+            <li><a href="{{ path('login') }}">{{ ux_icon('heroicons:arrow-right-on-rectangle', {'class': 'w-5 h-5'}) }} {{ 'navbar.login'|trans }}</a></li>
+          </ul>
+        </li>
       {% endif %}
       <!-- /user profile -->
     </ul>

--- a/templates/navbar.html.twig
+++ b/templates/navbar.html.twig
@@ -14,9 +14,9 @@
     </ul>
   </div>
   <div class="navbar-collapse collapse" id="navbar-mobile">
-    <ul class="nav navbar-nav">
+    <ul class="nav navbar-nav hidden-xs">
       <li>
-        <a class="sidebar-control sidebar-main-toggle hidden-xs">{{ ux_icon('heroicons:bars-3', {'class': 'w-8 h-8'}) }}</a>
+        <a class="sidebar-control sidebar-main-toggle">{{ ux_icon('heroicons:bars-3', {'class': 'w-8 h-8'}) }}</a>
       </li>
     </ul>
     <ul class="nav navbar-nav navbar-right">

--- a/templates/navbar.html.twig
+++ b/templates/navbar.html.twig
@@ -1,7 +1,9 @@
 {% import "helper.html.twig" as helper %}
 
-{% set current_route = app.request.attributes.get('_route') %}
-{% set route_params = app.request.attributes.get('_route_params') %}
+{# Error pages are rendered from a sub-request with _route/_route_params
+   stripped, so both need a fallback or the merge below gets null. #}
+{% set current_route = app.request.attributes.get('_route')|default('default_index') %}
+{% set route_params = app.request.attributes.get('_route_params')|default({}) %}
 {# Excludes setLocale/setUnits so a previous switcher click doesn't linger
    in every subsequent link generated from this same request. #}
 {% set nav_params = (route_params|merge(app.request.query.all))|filter((value, key) => key not in ['setLocale', 'setUnits']) %}

--- a/templates/navbar.html.twig
+++ b/templates/navbar.html.twig
@@ -1,12 +1,28 @@
 {% import "helper.html.twig" as helper %}
 
+{% set current_route = app.request.attributes.get('_route') %}
+{% set route_params = app.request.attributes.get('_route_params') %}
+{# Excludes setLocale/setUnits so a previous switcher click doesn't linger
+   in every subsequent link generated from this same request. #}
+{% set nav_params = (route_params|merge(app.request.query.all))|filter((value, key) => key not in ['setLocale', 'setUnits']) %}
+
 <div class="navbar navbar-inverse navbar-fixed-top">
   <div class="navbar-header">
     <a class="navbar-brand" href="{{ path('default_index') }}" style="padding:11px 20px;">
       <img src="{{ asset('images/logo_light.svg') }}" style="height:24px;margin:0;" alt="Captain Coaster">
     </a>
     <ul class="nav navbar-nav visible-xs-block">
-      <li><a data-toggle="collapse" data-target="#navbar-mobile">{{ ux_icon('heroicons:user', {'class': 'w-8 h-8'}) }}</a></li>
+      <li class="navbar-toggle-icon">
+        <a data-toggle="collapse" data-target="#navbar-mobile">
+          {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
+            {# Not img-xs: its fixed 32px fights the w-8 h-8 icons beside
+               it, which render at 2rem like everything else here. #}
+            {{ helper.profilePicture(app.user, 'img-circle') }}
+          {% else %}
+            {{ ux_icon('heroicons:user-circle', {'class': 'w-8 h-8'}) }}
+          {% endif %}
+        </a>
+      </li>
       <li><a class="sidebar-mobile-main-toggle">{{ ux_icon('heroicons:bars-3', {'class': 'w-8 h-8'}) }}</a></li>
       {% if pageHasFilters is defined %}
         <li><a class="sidebar-mobile-secondary-toggle">{{ ux_icon('heroicons:funnel', {'class': 'w-8 h-8'}) }}</a></li>
@@ -20,44 +36,8 @@
       </li>
     </ul>
     <ul class="nav navbar-nav navbar-right">
-      <li class="navbar-text">
-        <span id="editor-saved" class="label bg-success"></span>
-      </li>
-      <!-- notifications -->
+      <!-- user profile -->
       {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
-        <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-            {{ ux_icon('heroicons:bell', {'class': 'w-8 h-8'}) }}
-            <span class="visible-xs-inline-block position-right">{{ 'notif.title'|trans }}</span>
-            {% if app.user.unreadNotifications|length > 0 %}
-              <span class="badge bg-warning-400">{{ app.user.unreadNotifications|length }}</span>
-            {% endif %}
-          </a>
-          <div class="dropdown-menu dropdown-content">
-            <div class="dropdown-content-heading">{{ 'notif.title'|trans }}</div>
-            <ul class="media-list dropdown-content-body width-350">
-              {% for notif in app.user.unreadNotifications %}
-                <li class="media">
-                  <div class="media-left">
-                    <a href="#" class="btn bg-success-400 btn-rounded btn-icon btn-xs">
-                      {{ ux_icon('heroicons-solid:star', {'class': 'w-6 h-6'}) }}</a>
-                  </div>
-
-                  <div class="media-body">
-                    <a href="{{ path('notification_read', {'id': notif.id}) }}">
-                      {{ notif.message|trans({'%name%': notif.parameter|trans}) }}
-                    </a>
-                    <div class="media-annotation">{{ notif.createdAt|ago }}</div>
-                  </div>
-                </li>
-              {% else %}
-                <li>{{ 'notif.empty'|trans }}</li>
-              {% endfor %}
-            </ul>
-          </div>
-        </li>
-        <!-- /notifications -->
-        <!-- user profile -->
         <li class="dropdown dropdown-user">
           <a class="dropdown-toggle" data-toggle="dropdown">
             {{ helper.profilePicture(app.user, 'img-circle img-xs') }}
@@ -67,31 +47,58 @@
 
           <ul class="dropdown-menu dropdown-menu-right account-menu">
             <li class="account-menu-header">
-              {{ helper.profilePicture(app.user, 'img-circle img-xs') }}
+              {{ helper.profilePicture(app.user, 'img-circle img-lg') }}
               <div>
                 <div class="account-menu-name">{{ app.user.firstname }}</div>
                 <a href="{{ path('profile') }}">{{ 'navbar.profile'|trans }}</a>
               </div>
             </li>
             <li class="divider"></li>
-            <li class="account-menu-row">
-              <span class="account-menu-row-label">
-                {{ ux_icon('heroicons:language', {'class': 'w-5 h-5'}) }}
-                {{ 'navbar.language'|trans }}
-              </span>
-              <span class="account-menu-row-value">Français {{ ux_icon('heroicons:chevron-right', {'class': 'w-4 h-4'}) }}</span>
+            <!-- notifications -->
+            <li class="dropdown-submenu dropdown-submenu-hover dropdown-submenu-left">
+              <a href="#" class="dropdown-toggle account-menu-row" data-toggle="dropdown">
+                <span class="account-menu-row-label">
+                  {{ ux_icon('heroicons:bell', {'class': 'w-5 h-5'}) }}
+                  {{ 'notif.title'|trans }}
+                  {% if app.user.unreadNotifications|length > 0 %}
+                    <span class="badge bg-warning-400">{{ app.user.unreadNotifications|length }}</span>
+                  {% endif %}
+                </span>
+                <span class="account-menu-row-value">
+                  {{ ux_icon('heroicons:chevron-right', {'class': 'w-4 h-4'}) }}
+                </span>
+              </a>
+              <div class="dropdown-menu dropdown-content">
+                <div class="dropdown-content-heading">{{ 'notif.title'|trans }}</div>
+                <ul class="media-list dropdown-content-body width-350">
+                  {% for notif in app.user.unreadNotifications %}
+                    <li class="media">
+                      <div class="media-left">
+                        <a href="#" class="btn bg-success-400 btn-rounded btn-icon btn-xs">
+                          {{ ux_icon('heroicons-solid:star', {'class': 'w-6 h-6'}) }}</a>
+                      </div>
+
+                      <div class="media-body">
+                        <a href="{{ path('notification_read', {'id': notif.id}) }}">
+                          {{ notif.message|trans({'%name%': notif.parameter|trans}) }}
+                        </a>
+                        <div class="media-annotation">{{ notif.createdAt|ago }}</div>
+                      </div>
+                    </li>
+                  {% else %}
+                    <li>{{ 'notif.empty'|trans }}</li>
+                  {% endfor %}
+                </ul>
+              </div>
             </li>
-            <li class="account-menu-row">
-              <span class="account-menu-row-label">
-                {{ ux_icon('heroicons:scale', {'class': 'w-5 h-5'}) }}
-                {{ 'navbar.units'|trans }}
-              </span>
-              <span class="account-menu-row-value">Métrique {{ ux_icon('heroicons:chevron-right', {'class': 'w-4 h-4'}) }}</span>
-            </li>
+            <!-- /notifications -->
             <li class="divider"></li>
+            {{ _self.languageSubmenu(current_route, nav_params) }}
+            {{ _self.unitsSubmenu(current_route, nav_params) }}
             <li>
               <a href="{{ path('profile_settings') }}">{{ ux_icon('heroicons:cog-6-tooth', {'class': 'w-5 h-5'}) }} {{ 'navbar.settings'|trans }}</a>
             </li>
+            <li class="divider"></li>
             <li>
               <a href="{{ path('profile_ratings') }}">{{ ux_icon('heroicons:star', {'class': 'w-5 h-5'}) }} {{ 'navbar.rating'|trans }}</a>
             </li>
@@ -113,20 +120,8 @@
             {{ ux_icon('heroicons:user-circle', {'class': 'w-8 h-8'}) }}
           </a>
           <ul class="dropdown-menu dropdown-menu-right account-menu">
-            <li class="account-menu-row">
-              <span class="account-menu-row-label">
-                {{ ux_icon('heroicons:language', {'class': 'w-5 h-5'}) }}
-                {{ 'navbar.language'|trans }}
-              </span>
-              <span class="account-menu-row-value">Français {{ ux_icon('heroicons:chevron-right', {'class': 'w-4 h-4'}) }}</span>
-            </li>
-            <li class="account-menu-row">
-              <span class="account-menu-row-label">
-                {{ ux_icon('heroicons:scale', {'class': 'w-5 h-5'}) }}
-                {{ 'navbar.units'|trans }}
-              </span>
-              <span class="account-menu-row-value">Métrique {{ ux_icon('heroicons:chevron-right', {'class': 'w-4 h-4'}) }}</span>
-            </li>
+            {{ _self.languageSubmenu(current_route, nav_params) }}
+            {{ _self.unitsSubmenu(current_route, nav_params) }}
             <li class="divider"></li>
             <li><a href="{{ path('login') }}">{{ ux_icon('heroicons:arrow-right-on-rectangle', {'class': 'w-5 h-5'}) }} {{ 'navbar.login'|trans }}</a></li>
           </ul>
@@ -136,3 +131,57 @@
     </ul>
   </div>
 </div>
+
+{% macro languageSubmenu(current_route, nav_params) %}
+  <li class="dropdown-submenu dropdown-submenu-hover dropdown-submenu-left">
+    <a href="#" class="dropdown-toggle account-menu-row" data-toggle="dropdown">
+      <span class="account-menu-row-label">
+        {{ ux_icon('heroicons:language', {'class': 'w-5 h-5'}) }}
+        {{ 'navbar.language'|trans }}
+      </span>
+      <span class="account-menu-row-value">
+        {{ app.request.locale|trans }}
+        {{ ux_icon('heroicons:chevron-right', {'class': 'w-4 h-4'}) }}
+      </span>
+    </a>
+    <ul class="dropdown-menu">
+      {% for locale in locales %}
+        <li>
+          <a href="{{ path(current_route, nav_params|merge({_locale: locale, setLocale: 1})) }}">
+            {{ locale|trans }}
+            {% if locale == app.request.locale %}{{ ux_icon('heroicons:check', {'class': 'w-4 h-4'}) }}{% endif %}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </li>
+{% endmacro %}
+
+{% macro unitsSubmenu(current_route, nav_params) %}
+  <li class="dropdown-submenu dropdown-submenu-hover dropdown-submenu-left">
+    <a href="#" class="dropdown-toggle account-menu-row" data-toggle="dropdown">
+      <span class="account-menu-row-label">
+        {{ ux_icon('heroicons:scale', {'class': 'w-5 h-5'}) }}
+        {{ 'navbar.units'|trans }}
+      </span>
+      <span class="account-menu-row-value">
+        {{ units.isImperial() ? 'profile.settings.preferences.units.imperial'|trans : 'profile.settings.preferences.units.metric'|trans }}
+        {{ ux_icon('heroicons:chevron-right', {'class': 'w-4 h-4'}) }}
+      </span>
+    </a>
+    <ul class="dropdown-menu">
+      <li>
+        <a href="{{ path(current_route, nav_params|merge({setUnits: 'metric'})) }}">
+          {{ 'profile.settings.preferences.units.metric'|trans }}
+          {% if not units.isImperial() %}{{ ux_icon('heroicons:check', {'class': 'w-4 h-4'}) }}{% endif %}
+        </a>
+      </li>
+      <li>
+        <a href="{{ path(current_route, nav_params|merge({setUnits: 'imperial'})) }}">
+          {{ 'profile.settings.preferences.units.imperial'|trans }}
+          {% if units.isImperial() %}{{ ux_icon('heroicons:check', {'class': 'w-4 h-4'}) }}{% endif %}
+        </a>
+      </li>
+    </ul>
+  </li>
+{% endmacro %}

--- a/tests/EventSubscriber/LocaleCookieSubscriberTest.php
+++ b/tests/EventSubscriber/LocaleCookieSubscriberTest.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace App\Tests\EventSubscriber;
 
+use App\Entity\User;
 use App\EventSubscriber\LocaleCookieSubscriber;
 use App\Service\LocalePreferenceService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -16,10 +20,14 @@ use Symfony\Component\HttpKernel\KernelInterface;
 class LocaleCookieSubscriberTest extends TestCase
 {
     private LocaleCookieSubscriber $subscriber;
+    private Security&MockObject $security;
+    private EntityManagerInterface&MockObject $em;
 
     protected function setUp(): void
     {
-        $this->subscriber = new LocaleCookieSubscriber();
+        $this->security = $this->createMock(Security::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->subscriber = new LocaleCookieSubscriber($this->security, $this->em);
     }
 
     private function respond(Request $request): Response
@@ -35,6 +43,8 @@ class LocaleCookieSubscriberTest extends TestCase
 
     public function testSetsLocaleCookieToTheRequestsResolvedLocaleWhenSetLocaleIsPresent(): void
     {
+        $this->security->method('getUser')->willReturn(null);
+
         $request = Request::create('/fr/map/?setLocale=1');
         $request->setLocale('fr');
 
@@ -50,6 +60,8 @@ class LocaleCookieSubscriberTest extends TestCase
 
     public function testSetsLocaleCookieRegardlessOfSetLocaleValue(): void
     {
+        $this->security->method('getUser')->willReturn(null);
+
         // setLocale is a presence flag, not a value -- any value (or an
         // empty one) triggers the same behavior as long as the param
         // exists. The cookie value always comes from the request's own
@@ -66,6 +78,8 @@ class LocaleCookieSubscriberTest extends TestCase
 
     public function testDoesNothingWhenSetLocaleIsMissing(): void
     {
+        $this->security->method('getUser')->willReturn(null);
+
         $request = Request::create('/en/map/');
         $request->setLocale('en');
 
@@ -76,6 +90,8 @@ class LocaleCookieSubscriberTest extends TestCase
 
     public function testDoesNothingOnSubRequests(): void
     {
+        $this->security->method('getUser')->willReturn(null);
+
         $request = Request::create('/fr/map/?setLocale=1');
         $request->setLocale('fr');
         $kernel = $this->createMock(KernelInterface::class);
@@ -85,5 +101,35 @@ class LocaleCookieSubscriberTest extends TestCase
         $this->subscriber->onKernelResponse($event);
 
         $this->assertCount(0, $response->headers->getCookies());
+    }
+
+    public function testWritesToUserProfileInsteadOfCookieWhenLoggedIn(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getPreferredLocale')->willReturn('en');
+        $user->expects($this->once())->method('setPreferredLocale')->with('fr');
+        $this->em->expects($this->once())->method('flush');
+        $this->security->method('getUser')->willReturn($user);
+
+        $request = Request::create('/fr/map/?setLocale=1');
+        $request->setLocale('fr');
+
+        $response = $this->respond($request);
+
+        $this->assertCount(0, $response->headers->getCookies());
+    }
+
+    public function testDoesNotFlushWhenLocaleAlreadyMatchesProfile(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getPreferredLocale')->willReturn('fr');
+        $user->expects($this->never())->method('setPreferredLocale');
+        $this->em->expects($this->never())->method('flush');
+        $this->security->method('getUser')->willReturn($user);
+
+        $request = Request::create('/fr/map/?setLocale=1');
+        $request->setLocale('fr');
+
+        $this->respond($request);
     }
 }

--- a/tests/EventSubscriber/UnitsCookieSubscriberTest.php
+++ b/tests/EventSubscriber/UnitsCookieSubscriberTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EventSubscriber;
+
+use App\EventSubscriber\UnitsCookieSubscriber;
+use App\Entity\User;
+use App\Service\UnitsService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class UnitsCookieSubscriberTest extends TestCase
+{
+    private Security&MockObject $security;
+    private EntityManagerInterface&MockObject $em;
+    private UnitsCookieSubscriber $subscriber;
+
+    protected function setUp(): void
+    {
+        $this->security = $this->createMock(Security::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->subscriber = new UnitsCookieSubscriber($this->security, $this->em);
+    }
+
+    private function respond(Request $request): Response
+    {
+        $kernel = $this->createMock(KernelInterface::class);
+        $response = new Response();
+        $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $this->subscriber->onKernelResponse($event);
+
+        return $response;
+    }
+
+    public function testSetsUnitsCookieForAnonymousVisitor(): void
+    {
+        $this->security->method('getUser')->willReturn(null);
+        $request = Request::create('/en/map/?setUnits=imperial');
+
+        $response = $this->respond($request);
+
+        $cookie = $response->headers->getCookies()[0] ?? null;
+        $this->assertNotNull($cookie);
+        $this->assertSame(UnitsService::COOKIE_NAME, $cookie->getName());
+        $this->assertSame('imperial', $cookie->getValue());
+        $this->assertTrue($cookie->isSecure());
+        $this->assertTrue($cookie->isHttpOnly());
+    }
+
+    public function testWritesToProfileWhenLoggedIn(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getPreferredUnits')->willReturn('metric');
+        $user->expects($this->once())->method('setPreferredUnits')->with('imperial');
+        $this->em->expects($this->once())->method('flush');
+        $this->security->method('getUser')->willReturn($user);
+
+        $request = Request::create('/en/map/?setUnits=imperial');
+
+        $response = $this->respond($request);
+
+        $this->assertCount(0, $response->headers->getCookies());
+    }
+
+    public function testDoesNothingWhenSetUnitsIsMissing(): void
+    {
+        $this->security->method('getUser')->willReturn(null);
+        $request = Request::create('/en/map/');
+
+        $response = $this->respond($request);
+
+        $this->assertCount(0, $response->headers->getCookies());
+    }
+
+    public function testDoesNothingWhenSetUnitsValueIsInvalid(): void
+    {
+        $this->security->method('getUser')->willReturn(null);
+        $request = Request::create('/en/map/?setUnits=furlongs');
+
+        $response = $this->respond($request);
+
+        $this->assertCount(0, $response->headers->getCookies());
+    }
+
+    public function testDoesNothingOnSubRequests(): void
+    {
+        $this->security->method('getUser')->willReturn(null);
+        $request = Request::create('/en/map/?setUnits=imperial');
+        $kernel = $this->createMock(KernelInterface::class);
+        $response = new Response();
+        $event = new ResponseEvent($kernel, $request, HttpKernelInterface::SUB_REQUEST, $response);
+
+        $this->subscriber->onKernelResponse($event);
+
+        $this->assertCount(0, $response->headers->getCookies());
+    }
+}

--- a/tests/Security/GoogleAuthenticatorTest.php
+++ b/tests/Security/GoogleAuthenticatorTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Security;
 
 use App\Security\GoogleAuthenticator;
 use App\Service\ProfilePictureManager;
+use App\Service\UnitsService;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -25,6 +26,7 @@ class GoogleAuthenticatorTest extends TestCase
     private ProfilePictureManager&MockObject $profilePictureManager;
     private RouterInterface&MockObject $router;
     private LoggerInterface&MockObject $logger;
+    private UnitsService&MockObject $unitsService;
     private GoogleAuthenticator $authenticator;
 
     protected function setUp(): void
@@ -34,13 +36,15 @@ class GoogleAuthenticatorTest extends TestCase
         $this->profilePictureManager = $this->createMock(ProfilePictureManager::class);
         $this->router = $this->createMock(RouterInterface::class);
         $this->logger = $this->createMock(LoggerInterface::class);
+        $this->unitsService = $this->createMock(UnitsService::class);
 
         $this->authenticator = new GoogleAuthenticator(
             $this->clientRegistry,
             $this->em,
             $this->profilePictureManager,
             $this->router,
-            $this->logger
+            $this->logger,
+            $this->unitsService
         );
     }
 
@@ -98,5 +102,28 @@ class GoogleAuthenticatorTest extends TestCase
         $response = $this->authenticator->onAuthenticationSuccess($request, $token, 'main');
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
+    }
+
+    public function testFindOrCreateUserInitializesPreferredUnitsFromRequest(): void
+    {
+        $googleUser = $this->createMock(\League\OAuth2\Client\Provider\GoogleUser::class);
+        $googleUser->method('getId')->willReturn('google-123');
+        $googleUser->method('getEmail')->willReturn('new@example.com');
+
+        $this->em->method('getRepository')->willReturn($this->createConfiguredMock(
+            \Doctrine\ORM\EntityRepository::class,
+            ['findOneBy' => null]
+        ));
+
+        $this->unitsService->expects($this->once())
+            ->method('guessUnitsFromRequest')
+            ->willReturn('imperial');
+
+        $request = $this->requestWithSession();
+
+        $reflection = new \ReflectionMethod($this->authenticator, 'findOrCreateUser');
+        $user = $reflection->invoke($this->authenticator, $googleUser, $request);
+
+        $this->assertSame('imperial', $user->getPreferredUnits());
     }
 }

--- a/tests/Security/GoogleAuthenticatorTest.php
+++ b/tests/Security/GoogleAuthenticatorTest.php
@@ -126,4 +126,27 @@ class GoogleAuthenticatorTest extends TestCase
 
         $this->assertSame('imperial', $user->getPreferredUnits());
     }
+
+    public function testFindOrCreateUserFallsBackToRequestLocaleWhenSessionHasNoLocaleAtLogin(): void
+    {
+        // locale_at_login intentionally not set in session -- must match
+        // onAuthenticationSuccess/onAuthenticationFailure's fallback
+        // (the request's own locale), not a hardcoded 'en'.
+        $googleUser = $this->createMock(\League\OAuth2\Client\Provider\GoogleUser::class);
+        $googleUser->method('getId')->willReturn('google-456');
+        $googleUser->method('getEmail')->willReturn('new2@example.com');
+
+        $this->em->method('getRepository')->willReturn($this->createConfiguredMock(
+            \Doctrine\ORM\EntityRepository::class,
+            ['findOneBy' => null]
+        ));
+
+        $request = $this->requestWithSession();
+        $request->setLocale('fr');
+
+        $reflection = new \ReflectionMethod($this->authenticator, 'findOrCreateUser');
+        $user = $reflection->invoke($this->authenticator, $googleUser, $request);
+
+        $this->assertSame('fr', $user->getPreferredLocale());
+    }
 }

--- a/tests/Service/ReviewLanguagePreferenceServiceTest.php
+++ b/tests/Service/ReviewLanguagePreferenceServiceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Entity\User;
+use App\Service\ReviewLanguagePreferenceService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+
+class ReviewLanguagePreferenceServiceTest extends TestCase
+{
+    private Security&MockObject $security;
+    private ReviewLanguagePreferenceService $service;
+
+    protected function setUp(): void
+    {
+        $this->security = $this->createMock(Security::class);
+        $this->service = new ReviewLanguagePreferenceService($this->security);
+    }
+
+    public function testAnonymousVisitorGetsCurrentPageLocaleOnly(): void
+    {
+        $this->security->method('getUser')->willReturn(null);
+        $request = Request::create('/de/coasters/1');
+        $request->setLocale('de');
+
+        $this->assertSame(['de'], $this->service->resolve($request));
+    }
+
+    public function testLoggedInUserWithNoExplicitPreferenceGetsOwnLocaleOnly(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getPreferredReviewLanguages')->willReturn([]);
+        $user->method('getPreferredLocale')->willReturn('de');
+        $this->security->method('getUser')->willReturn($user);
+
+        $request = Request::create('/en/coasters/1');
+        $request->setLocale('en');
+
+        $this->assertSame(['de'], $this->service->resolve($request));
+    }
+
+    public function testLoggedInUserWithExplicitPreferenceGetsThatList(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getPreferredReviewLanguages')->willReturn(['de', 'en']);
+        $this->security->method('getUser')->willReturn($user);
+
+        $request = Request::create('/en/coasters/1');
+        $request->setLocale('en');
+
+        $this->assertSame(['de', 'en'], $this->service->resolve($request));
+    }
+}

--- a/tests/Service/UnitsServiceTest.php
+++ b/tests/Service/UnitsServiceTest.php
@@ -202,47 +202,12 @@ class UnitsServiceTest extends TestCase
         $this->assertSame('6 mi', $this->service->kmOrMi(10));
     }
 
-    public function testGuessUnitsFromRequestUsesCfIpCountryUs(): void
-    {
-        $request = Request::create('/');
-        $request->headers->set('CF-IPCountry', 'US');
-
-        $this->assertSame('imperial', $this->service->guessUnitsFromRequest($request));
-    }
-
-    public function testGuessUnitsFromRequestUsesCfIpCountryGb(): void
-    {
-        $request = Request::create('/');
-        $request->headers->set('CF-IPCountry', 'GB');
-
-        $this->assertSame('imperial', $this->service->guessUnitsFromRequest($request));
-    }
-
-    public function testGuessUnitsFromRequestCfIpCountryMetricElsewhere(): void
-    {
-        $request = Request::create('/');
-        $request->headers->set('CF-IPCountry', 'FR');
-
-        $this->assertSame('metric', $this->service->guessUnitsFromRequest($request));
-    }
-
-    public function testGuessUnitsFromRequestFallsBackToAcceptLanguageWhenCfHeaderAbsent(): void
+    public function testGuessUnitsFromRequestUsesAcceptLanguage(): void
     {
         $request = Request::create('/');
         $request->headers->set('Accept-Language', 'en-US,en;q=0.9');
 
         $this->assertSame('imperial', $this->service->guessUnitsFromRequest($request));
-    }
-
-    public function testGuessUnitsFromRequestCfIpCountryTakesPriorityOverAcceptLanguage(): void
-    {
-        // CF-IPCountry says France (metric); Accept-Language alone would
-        // have said US (imperial) -- the real-country signal wins.
-        $request = Request::create('/');
-        $request->headers->set('CF-IPCountry', 'FR');
-        $request->headers->set('Accept-Language', 'en-US,en;q=0.9');
-
-        $this->assertSame('metric', $this->service->guessUnitsFromRequest($request));
     }
 
     public function testIsImperialForAnonymousUserUsesCookieOverAcceptLanguage(): void
@@ -295,28 +260,5 @@ class UnitsServiceTest extends TestCase
         $this->requestStack->push($request);
 
         $this->assertTrue($this->service->isImperial());
-    }
-
-    public function testGuessUnitsFromRequestTreatsCfIpCountryXxAsAbsentAndFallsBackToAcceptLanguage(): void
-    {
-        // Cloudflare sends 'XX' when the visitor's country is unknown --
-        // not a real country, so it shouldn't override a legitimate
-        // Accept-Language signal by forcing metric.
-        $request = Request::create('/');
-        $request->headers->set('CF-IPCountry', 'XX');
-        $request->headers->set('Accept-Language', 'en-US,en;q=0.9');
-
-        $this->assertSame('imperial', $this->service->guessUnitsFromRequest($request));
-    }
-
-    public function testGuessUnitsFromRequestTreatsCfIpCountryT1AsAbsentAndFallsBackToAcceptLanguage(): void
-    {
-        // Cloudflare sends 'T1' for Tor exit nodes -- also not a real
-        // country.
-        $request = Request::create('/');
-        $request->headers->set('CF-IPCountry', 'T1');
-        $request->headers->set('Accept-Language', 'en-US,en;q=0.9');
-
-        $this->assertSame('imperial', $this->service->guessUnitsFromRequest($request));
     }
 }

--- a/tests/Service/UnitsServiceTest.php
+++ b/tests/Service/UnitsServiceTest.php
@@ -244,4 +244,26 @@ class UnitsServiceTest extends TestCase
 
         $this->assertSame('metric', $this->service->guessUnitsFromRequest($request));
     }
+
+    public function testIsImperialForAnonymousUserUsesCookieOverAcceptLanguage(): void
+    {
+        $this->security->method('getUser')->willReturn(null);
+        $request = Request::create('/');
+        $request->headers->set('Accept-Language', 'fr-FR,fr;q=0.9');
+        $request->cookies->set(UnitsService::COOKIE_NAME, 'imperial');
+        $this->requestStack->push($request);
+
+        $this->assertTrue($this->service->isImperial());
+    }
+
+    public function testIsImperialForAnonymousUserIgnoresInvalidCookieValue(): void
+    {
+        $this->security->method('getUser')->willReturn(null);
+        $request = Request::create('/');
+        $request->headers->set('Accept-Language', 'en-US,en;q=0.9');
+        $request->cookies->set(UnitsService::COOKIE_NAME, 'furlongs');
+        $this->requestStack->push($request);
+
+        $this->assertTrue($this->service->isImperial());
+    }
 }

--- a/tests/Service/UnitsServiceTest.php
+++ b/tests/Service/UnitsServiceTest.php
@@ -201,4 +201,47 @@ class UnitsServiceTest extends TestCase
 
         $this->assertSame('6 mi', $this->service->kmOrMi(10));
     }
+
+    public function testGuessUnitsFromRequestUsesCfIpCountryUs(): void
+    {
+        $request = Request::create('/');
+        $request->headers->set('CF-IPCountry', 'US');
+
+        $this->assertSame('imperial', $this->service->guessUnitsFromRequest($request));
+    }
+
+    public function testGuessUnitsFromRequestUsesCfIpCountryGb(): void
+    {
+        $request = Request::create('/');
+        $request->headers->set('CF-IPCountry', 'GB');
+
+        $this->assertSame('imperial', $this->service->guessUnitsFromRequest($request));
+    }
+
+    public function testGuessUnitsFromRequestCfIpCountryMetricElsewhere(): void
+    {
+        $request = Request::create('/');
+        $request->headers->set('CF-IPCountry', 'FR');
+
+        $this->assertSame('metric', $this->service->guessUnitsFromRequest($request));
+    }
+
+    public function testGuessUnitsFromRequestFallsBackToAcceptLanguageWhenCfHeaderAbsent(): void
+    {
+        $request = Request::create('/');
+        $request->headers->set('Accept-Language', 'en-US,en;q=0.9');
+
+        $this->assertSame('imperial', $this->service->guessUnitsFromRequest($request));
+    }
+
+    public function testGuessUnitsFromRequestCfIpCountryTakesPriorityOverAcceptLanguage(): void
+    {
+        // CF-IPCountry says France (metric); Accept-Language alone would
+        // have said US (imperial) -- the real-country signal wins.
+        $request = Request::create('/');
+        $request->headers->set('CF-IPCountry', 'FR');
+        $request->headers->set('Accept-Language', 'en-US,en;q=0.9');
+
+        $this->assertSame('metric', $this->service->guessUnitsFromRequest($request));
+    }
 }

--- a/tests/Service/UnitsServiceTest.php
+++ b/tests/Service/UnitsServiceTest.php
@@ -51,7 +51,7 @@ class UnitsServiceTest extends TestCase
     public function testIsImperialForLoggedInUserUsesProfilePreferenceRegardlessOfBrowserLanguage(): void
     {
         $user = $this->createMock(User::class);
-        $user->method('isImperial')->willReturn(true);
+        $user->method('getPreferredUnits')->willReturn('imperial');
         $this->security->method('getUser')->willReturn($user);
 
         $this->pushRequestWithAcceptLanguage('fr-FR,fr;q=0.9');

--- a/tests/Service/UnitsServiceTest.php
+++ b/tests/Service/UnitsServiceTest.php
@@ -266,4 +266,57 @@ class UnitsServiceTest extends TestCase
 
         $this->assertTrue($this->service->isImperial());
     }
+
+    public function testIsImperialAppliesSetUnitsQueryParamImmediatelyRegardlessOfUserOrCookie(): void
+    {
+        // The very request carrying ?setUnits=imperial must already reflect
+        // it, before UnitsCookieSubscriber (KernelEvents::RESPONSE) has had
+        // a chance to persist it for future requests -- otherwise the page
+        // the visitor lands on after clicking the switcher still renders
+        // with the old units.
+        $user = $this->createMock(User::class);
+        $user->method('getPreferredUnits')->willReturn('metric');
+        $this->security->method('getUser')->willReturn($user);
+
+        $request = Request::create('/?setUnits=imperial');
+        $request->cookies->set(UnitsService::COOKIE_NAME, 'metric');
+        $this->requestStack->push($request);
+
+        $this->assertTrue($this->service->isImperial());
+    }
+
+    public function testIsImperialIgnoresInvalidSetUnitsQueryParam(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getPreferredUnits')->willReturn('imperial');
+        $this->security->method('getUser')->willReturn($user);
+
+        $request = Request::create('/?setUnits=furlongs');
+        $this->requestStack->push($request);
+
+        $this->assertTrue($this->service->isImperial());
+    }
+
+    public function testGuessUnitsFromRequestTreatsCfIpCountryXxAsAbsentAndFallsBackToAcceptLanguage(): void
+    {
+        // Cloudflare sends 'XX' when the visitor's country is unknown --
+        // not a real country, so it shouldn't override a legitimate
+        // Accept-Language signal by forcing metric.
+        $request = Request::create('/');
+        $request->headers->set('CF-IPCountry', 'XX');
+        $request->headers->set('Accept-Language', 'en-US,en;q=0.9');
+
+        $this->assertSame('imperial', $this->service->guessUnitsFromRequest($request));
+    }
+
+    public function testGuessUnitsFromRequestTreatsCfIpCountryT1AsAbsentAndFallsBackToAcceptLanguage(): void
+    {
+        // Cloudflare sends 'T1' for Tor exit nodes -- also not a real
+        // country.
+        $request = Request::create('/');
+        $request->headers->set('CF-IPCountry', 'T1');
+        $request->headers->set('Accept-Language', 'en-US,en;q=0.9');
+
+        $this->assertSame('imperial', $this->service->guessUnitsFromRequest($request));
+    }
 }

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -262,7 +262,7 @@ profile:
                 label: Anzeigen von Entfernungen und Statistiken in
             preferredReviewLanguages:
                 label: 'Bewertungen anzeigen in'
-                help: 'Leer lassen, um nur Bewertungen in Ihrer Sprache zu sehen.'
+                help: 'Leer lassen, um nur Bewertungen in Ihrer bevorzugten Sprache zu sehen.'
             addTodayDateWhenRating:
                 label: Heutiges Datum bei einer neuen Bewertung hinzufügen
         advanced:

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -172,8 +172,8 @@ filters:
                 asc: Von der ältesten zur neuesten
                 desc: Von der neuesten zur ältesten
             value:
-                asc: Von der schlechtesten bis zu besten Bewertungen
-                desc: Von der besten bis zu schlechtesten Bewertungen
+                asc: Von der schlechtesten zur besten
+                desc: Von der besten zur schlechtesten
 
 user_profile:
     title: 'Profil • {name}'

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -343,6 +343,8 @@ navbar:
     logout: Abmelden
     tops: Meine Tops
     my_map: Meine Karte
+    language: Sprache
+    units: Einheiten
 
 sidebar:
     index: Home

--- a/translations/messages+intl-icu.de.yml
+++ b/translations/messages+intl-icu.de.yml
@@ -260,8 +260,9 @@ profile:
                 metric: Internationale Einheitensystem
                 imperial: Britische Einheitensystem
                 label: Anzeigen von Entfernungen und Statistiken in
-            displayReviewsInAllLanguages:
-                label: Anzeigen in verschiedenen Sprachen verfasste Bewertungen
+            preferredReviewLanguages:
+                label: 'Bewertungen anzeigen in'
+                help: 'Leer lassen, um nur Bewertungen in Ihrer Sprache zu sehen.'
             addTodayDateWhenRating:
                 label: Heutiges Datum bei einer neuen Bewertung hinzufügen
         advanced:

--- a/translations/messages+intl-icu.en.yml
+++ b/translations/messages+intl-icu.en.yml
@@ -256,7 +256,7 @@ profile:
                 label: 'Display distances and statistics in'
             preferredReviewLanguages:
                 label: 'Show reviews written in'
-                help: 'Leave empty to only see reviews in your own language.'
+                help: 'Leave empty to only see reviews in your preferred language.'
             addTodayDateWhenRating:
                 label: "Add today's date on a new rating"
         advanced:

--- a/translations/messages+intl-icu.en.yml
+++ b/translations/messages+intl-icu.en.yml
@@ -337,6 +337,8 @@ navbar:
     logout: 'Logout'
     tops: 'My tops'
     my_map: 'My map'
+    language: 'Language'
+    units: 'Units'
 
 sidebar:
     index: 'Home'

--- a/translations/messages+intl-icu.en.yml
+++ b/translations/messages+intl-icu.en.yml
@@ -167,8 +167,8 @@ filters:
                 asc: 'Oldest to newest'
                 desc: 'Newest to oldest'
             value:
-                asc: 'Lowest to higher rating'
-                desc: 'Higher to lowest rating'
+                asc: 'Lowest to highest'
+                desc: 'Highest to lowest'
 
 user_profile:
     title: 'Profile • {name}'

--- a/translations/messages+intl-icu.en.yml
+++ b/translations/messages+intl-icu.en.yml
@@ -254,8 +254,9 @@ profile:
                 metric: 'Metric units'
                 imperial: 'Imperial units'
                 label: 'Display distances and statistics in'
-            displayReviewsInAllLanguages:
-                label: 'Display reviews written in different languages'
+            preferredReviewLanguages:
+                label: 'Show reviews written in'
+                help: 'Leave empty to only see reviews in your own language.'
             addTodayDateWhenRating:
                 label: "Add today's date on a new rating"
         advanced:

--- a/translations/messages+intl-icu.es.yml
+++ b/translations/messages+intl-icu.es.yml
@@ -342,6 +342,8 @@ navbar:
     logout: Cerrar sesión
     tops: 'Mis tops'
     my_map: Mi mapa
+    language: Idioma
+    units: Unidades
 
 sidebar:
     index: Pagina de inicio

--- a/translations/messages+intl-icu.es.yml
+++ b/translations/messages+intl-icu.es.yml
@@ -259,8 +259,9 @@ profile:
                 metric: Sistema Internacional de unidades
                 imperial: Sistema anglosajón de unidades
                 label: Mostrar distancias y estadísticas en
-            displayReviewsInAllLanguages:
-                label: Mostrar reseñas escritas en diferentes lenguas
+            preferredReviewLanguages:
+                label: 'Mostrar reseñas escritas en'
+                help: 'Déjelo vacío para ver solo reseñas en su idioma.'
             addTodayDateWhenRating:
                 label: Añadir la fecha de hoy en una nueva calificación
         advanced:

--- a/translations/messages+intl-icu.es.yml
+++ b/translations/messages+intl-icu.es.yml
@@ -261,7 +261,7 @@ profile:
                 label: Mostrar distancias y estadísticas en
             preferredReviewLanguages:
                 label: 'Mostrar reseñas escritas en'
-                help: 'Déjelo vacío para ver solo reseñas en su idioma.'
+                help: 'Déjelo vacío para ver solo reseñas en su idioma preferido.'
             addTodayDateWhenRating:
                 label: Añadir la fecha de hoy en una nueva calificación
         advanced:

--- a/translations/messages+intl-icu.es.yml
+++ b/translations/messages+intl-icu.es.yml
@@ -172,8 +172,8 @@ filters:
                 asc: De la más antigua a la más reciente
                 desc: De la más reciente a la más antigua
             value:
-                asc: De la nota más alta a la más baja
-                desc: De la nota más baja a la más alta
+                asc: De la más baja a la más alta
+                desc: De la más alta a la más baja
 
 user_profile:
     title: 'Perfil • {name}'

--- a/translations/messages+intl-icu.fr.yml
+++ b/translations/messages+intl-icu.fr.yml
@@ -342,6 +342,8 @@ navbar:
     logout: Déconnexion
     tops: Mes tops
     my_map: Ma carte
+    language: Langue
+    units: Unités
 
 sidebar:
     index: Accueil

--- a/translations/messages+intl-icu.fr.yml
+++ b/translations/messages+intl-icu.fr.yml
@@ -172,8 +172,8 @@ filters:
                 asc: Du plus ancien au plus récent
                 desc: Du plus récent au plus ancien
             value:
-                asc: De la moins bonne à la meilleure note
-                desc: De la meilleure à la moins bonne note
+                asc: De la moins bonne à la meilleure
+                desc: De la meilleure à la moins bonne
 
 user_profile:
     title: 'Profil • {name}'

--- a/translations/messages+intl-icu.fr.yml
+++ b/translations/messages+intl-icu.fr.yml
@@ -259,8 +259,9 @@ profile:
                 metric: Unités métriques
                 imperial: Unités impériales
                 label: Afficher les distances et statistiques en
-            displayReviewsInAllLanguages:
-                label: Afficher les avis écrits en différentes langues
+            preferredReviewLanguages:
+                label: 'Afficher les avis écrits en'
+                help: 'Laissez vide pour ne voir que les avis dans votre langue.'
             addTodayDateWhenRating:
                 label: Ajouter la date du jour quand je note un nouveau coaster
         advanced:

--- a/translations/messages+intl-icu.fr.yml
+++ b/translations/messages+intl-icu.fr.yml
@@ -261,7 +261,7 @@ profile:
                 label: Afficher les distances et statistiques en
             preferredReviewLanguages:
                 label: 'Afficher les avis écrits en'
-                help: 'Laissez vide pour ne voir que les avis dans votre langue.'
+                help: 'Laissez vide pour ne voir que les avis dans votre langue préférée.'
             addTodayDateWhenRating:
                 label: Ajouter la date du jour quand je note un nouveau coaster
         advanced:


### PR DESCRIPTION
## Summary

Replaces two legacy boolean prefs with richer per-user settings, and moves
locale/units switching into a redesigned account-menu panel in the navbar.

- `User::$imperial` → `User::$preferredUnits` ('metric'|'imperial')
- `User::$displayReviewsInAllLanguages` → `User::$preferredReviewLanguages` (locale array)
- New `UnitsCookieSubscriber`, symmetric to the existing `LocaleCookieSubscriber`: writes straight to the profile when logged in, falls back to a cookie for anonymous visitors
- `preferredUnits` now initialized from the browser guess at account creation (was never initialized before)
- Review text (not the rating) is redacted per-viewer based on preferred review languages on the coaster page and homepage
- Navbar account-menu panel redesigned (desktop + mobile) with working language and units switcher submenus, using the theme's native dropdown-submenu system
- Profile Settings and the admin panel updated for the new multi-select review-language preference

## Test plan

- [x] `vendor/bin/phpunit` — 225/225 passing
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `vendor/bin/php-cs-fixer fix --dry-run` — clean
- [x] `bin/console lint:twig` / `lint:container` — clean
- [x] Both migrations run successfully against a real database
- [x] Manually verified navbar language/units switching end-to-end (desktop + mobile, logged in + anonymous)
- [x] Manually verified error pages (404/etc.) render correctly