### PR TITLE
perf(reviews): add has_review generated column + index for review feeds

### DIFF
--- a/migrations/Version20260830100000.php
+++ b/migrations/Version20260830100000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260830100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add ridden_coaster.has_review (generated from review IS NOT NULL) with a supporting index, so latest/all-reviews feeds can use an index instead of a full table scan + filesort';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE ridden_coaster ADD has_review TINYINT(1) GENERATED ALWAYS AS (review IS NOT NULL) VIRTUAL');
+        $this->addSql('CREATE INDEX idx_ridden_coaster_has_review_updated_at ON ridden_coaster (has_review, updated_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_ridden_coaster_has_review_updated_at ON ridden_coaster');
+        $this->addSql('ALTER TABLE ridden_coaster DROP has_review');
+    }
+}

--- a/src/Entity/RiddenCoaster.php
+++ b/src/Entity/RiddenCoaster.php
@@ -16,6 +16,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\UniqueConstraint(name: 'user_coaster_unique', columns: ['coaster_id', 'user_id'])]
 #[ORM\Index(name: 'idx_ridden_coaster_moderated_at', columns: ['moderated_at'])]
+#[ORM\Index(name: 'idx_ridden_coaster_has_review_updated_at', columns: ['has_review', 'updated_at'])]
 #[ORM\Entity(repositoryClass: RiddenCoasterRepository::class)]
 #[UniqueEntity(['coaster', 'user'])]
 #[CaptainConstraints\ValidRideDate]
@@ -45,6 +46,10 @@ class RiddenCoaster
 
     #[ORM\Column(type: Types::STRING, length: 5)]
     private string $language = 'en';
+
+    /** DB-generated (mirrors `review IS NOT NULL`) for idx_ridden_coaster_has_review_updated_at -- never run schema:update --force, it'll try to drop the generated expression. */
+    #[ORM\Column(type: Types::BOOLEAN, insertable: false, updatable: false)]
+    private bool $hasReview = false;
 
     /** @var Collection<int, Tag> */
     #[ORM\ManyToMany(targetEntity: Tag::class)]
@@ -164,6 +169,11 @@ class RiddenCoaster
     public function getLanguage(): string
     {
         return $this->language;
+    }
+
+    public function isHasReview(): bool
+    {
+        return $this->hasReview;
     }
 
     public function addPro(Tag $pro): self

--- a/src/Repository/RiddenCoasterRepository.php
+++ b/src/Repository/RiddenCoasterRepository.php
@@ -241,12 +241,12 @@ class RiddenCoasterRepository extends ServiceEntityRepository
             ->createQueryBuilder()
             ->select('r')
             ->addSelect(
-                'CASE WHEN r.language IN (:preferredReviewLanguages) AND r.review IS NOT NULL THEN 0 ELSE 1 END AS HIDDEN languagePriority'
+                'CASE WHEN r.language IN (:preferredReviewLanguages) THEN 0 ELSE 1 END AS HIDDEN languagePriority'
             )
             ->addSelect('u')
             ->from(RiddenCoaster::class, 'r')
             ->innerJoin('r.user', 'u')
-            ->where('r.review is not null')
+            ->where('r.hasReview = 1')
             ->andWhere('u.enabled = 1')
             ->orderBy('languagePriority', 'asc')
             ->addOrderBy('r.updatedAt', 'desc')
@@ -331,7 +331,7 @@ class RiddenCoasterRepository extends ServiceEntityRepository
             ->select('count(1)')
             ->from(RiddenCoaster::class, 'r')
             ->innerJoin('r.user', 'u')
-            ->where('r.review is not null')
+            ->where('r.hasReview = 1')
             ->andWhere('r.language IN (:preferredReviewLanguages)')
             ->andWhere('u.enabled = 1')
             ->setParameter('preferredReviewLanguages', $preferredReviewLanguages)
@@ -343,7 +343,7 @@ class RiddenCoasterRepository extends ServiceEntityRepository
             ->select('r, u')
             ->from(RiddenCoaster::class, 'r')
             ->innerJoin('r.user', 'u')
-            ->where('r.review is not null')
+            ->where('r.hasReview = 1')
             ->andWhere('r.language IN (:preferredReviewLanguages)')
             ->andWhere('u.enabled = 1')
             ->orderBy('r.updatedAt', 'desc')

--- a/tests/Repository/RiddenCoasterRepositoryTest.php
+++ b/tests/Repository/RiddenCoasterRepositoryTest.php
@@ -13,11 +13,12 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Unit tests for RiddenCoasterRepository::countTop100ForUser().
+ * Unit tests for RiddenCoasterRepository.
  *
  * Uses real QueryBuilder instances (built against a mocked EntityManager) so the
  * generated DQL is genuine, only the final Query execution is stubbed — this
- * catches DQL-building regressions (e.g. a hardcoded Status id creeping back in)
+ * catches DQL-building regressions (e.g. a hardcoded Status id creeping back in,
+ * or a filter reverting to the un-indexable `review IS NOT NULL` predicate)
  * that a fully-mocked QueryBuilder would miss.
  */
 class RiddenCoasterRepositoryTest extends TestCase
@@ -101,5 +102,51 @@ class RiddenCoasterRepositoryTest extends TestCase
         $result = $this->repository->countTop100ForUser(new User());
 
         $this->assertSame(['nb_top100' => 5, 'nb_top100_operating' => 0], $result);
+    }
+
+    public function testGetLatestReviewsFiltersOnHasReviewColumn(): void
+    {
+        $dql = null;
+        $this->em->method('createQuery')->willReturnCallback(function (string $capturedDql) use (&$dql) {
+            $dql = $capturedDql;
+
+            $query = $this->createMock(Query::class);
+            $query->method('setParameters')->willReturnSelf();
+            $query->method('setFirstResult')->willReturnSelf();
+            $query->method('setMaxResults')->willReturnSelf();
+            $query->method('enableResultCache')->willReturnSelf();
+            $query->method('getResult')->willReturn([]);
+
+            return $query;
+        });
+
+        $this->repository->getLatestReviews(['en', 'fr'], 3);
+
+        // Must use the generated has_review column (idx_ridden_coaster_has_review_updated_at)
+        // rather than `review IS NOT NULL`, which can't use an index on a longtext column.
+        $this->assertStringContainsString('r.hasReview = 1', $dql);
+        $this->assertStringNotContainsString('r.review', $dql);
+    }
+
+    public function testFindAllReviewsFiltersOnHasReviewColumn(): void
+    {
+        $capturedDql = [];
+        $this->em->method('createQuery')->willReturnCallback(function (string $dql) use (&$capturedDql) {
+            $capturedDql[] = $dql;
+
+            $query = $this->createMock(Query::class);
+            $query->method('getSingleScalarResult')->willReturn(0);
+            $query->method('setHint')->willReturnSelf();
+
+            return $query;
+        });
+
+        $this->repository->findAllReviews(['en', 'fr']);
+
+        $this->assertCount(2, $capturedDql, 'Expected one count query and one select query');
+        foreach ($capturedDql as $dql) {
+            $this->assertStringContainsString('r.hasReview = 1', $dql);
+            $this->assertStringNotContainsString('r.review', $dql);
+        }
     }
 }


### PR DESCRIPTION
## Summary

`getLatestReviews` (homepage feed) and `findAllReviews` (`/reviews` listing) filter on `review IS NOT NULL`, which can't use an index on a `longtext` column. EXPLAIN showed a full table scan + filesort over all ~800k `ridden_coaster` rows on every result-cache miss / every paginated request.

- Adds `ridden_coaster.has_review`, a virtual generated column (`GENERATED ALWAYS AS (review IS NOT NULL) VIRTUAL`) mirroring the existing predicate, backed by `idx_ridden_coaster_has_review_updated_at (has_review, updated_at)`
- `getLatestReviews` and `findAllReviews` now filter on `r.hasReview = 1` instead, letting MySQL use the index and return pre-sorted rows
- `RiddenCoaster::$hasReview` is mapped read-only (`insertable: false, updatable: false`) — MySQL computes it, Doctrine never writes it

Measured against a copy of the real ~800k-row table: page 1 latency ~379ms → ~0.1ms, page 50 ~373ms → ~0.5ms.

Doctrine has no concept of a DB-generated column, so a bare `doctrine:schema:validate` (or `schema:update --force`) will misread `has_review` as drift and propose dropping the generated expression. CI passes `--skip-sync`, which skips that check, so this is safe there — confirmed by running the exact CI command against a schema-accurate scratch DB. Flagged with a comment on the property; never run `schema:update --force` against this table.

## Test plan

- [x] `vendor/bin/phpunit` — 222/222 passing (2 new regression tests assert the generated DQL references `hasReview`, not `review`)
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `vendor/bin/php-cs-fixer fix --dry-run` — clean
- [x] Migration applied/rolled back against a copy of the real ~800k-row `ridden_coaster` table (0 mismatches between `has_review` and `review IS NOT NULL`; INSERT/UPDATE correctly recompute the generated value)
- [x] Ran through actual `doctrine:migrations:migrate` tooling end-to-end against a schema-accurate scratch DB (8.5ms)
- [x] `doctrine:schema:validate --skip-sync` (exact CI command) passes clean