### PR TITLE
perf: session blob, collection hydration, and review tag N+1

### DIFF
--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -10,6 +10,11 @@ framework:
         #app: cache.adapter.redis
         default_redis_provider: '%env(REDIS_URL)%'
 
+        # Filesystem pools default to var/cache/<env>/pools, which cache:clear
+        # wipes on every deploy. Keep them out of the cache dir so they actually
+        # persist, as the comment above promises.
+        directory: '%kernel.project_dir%/var/pools'
+
         # APCu (not recommended with heavy random-write workloads as memory fragmentation can cause perf issues)
         #app: cache.adapter.apcu
 
@@ -19,7 +24,9 @@ framework:
             search.cache_pool:
                 adapter: cache.adapter.redis
 
-            # Sitemap cache (Redis for persistent data across deployments)
+            # Sitemap cache. Filesystem, not Redis: the payload reached 14.5 MB
+            # as a single key, and Redis is single-threaded — every GET of it
+            # stalled every other client, session reads included.
             sitemap.cache_pool:
-                adapter: cache.adapter.redis
+                adapter: cache.adapter.filesystem
                 default_lifetime: 604800 # 7 days

--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -10,11 +10,6 @@ framework:
         #app: cache.adapter.redis
         default_redis_provider: '%env(REDIS_URL)%'
 
-        # Filesystem pools default to var/cache/<env>/pools, which cache:clear
-        # wipes on every deploy. Keep them out of the cache dir so they actually
-        # persist, as the comment above promises.
-        directory: '%kernel.project_dir%/var/pools'
-
         # APCu (not recommended with heavy random-write workloads as memory fragmentation can cause perf issues)
         #app: cache.adapter.apcu
 

--- a/migrations/Version20260830180000.php
+++ b/migrations/Version20260830180000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260830180000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Index notification(user_id, is_read, created_at) for the navbar unread lookup';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_notification_user_unread ON notification (user_id, is_read, created_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_notification_user_unread ON notification');
+    }
+}

--- a/src/Command/DevLoginLinkCommand.php
+++ b/src/Command/DevLoginLinkCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Repository\UserRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
+
+/**
+ * Logs into a local session as any user, for reproducing logged-in-only behaviour
+ * against a production dump.
+ *
+ * Deliberately a console command reusing the existing login_link firewall rather
+ * than a /dev/login route: it adds no routable surface, and it authenticates
+ * through the same signed, expiring, use-capped path a real magic link takes.
+ */
+#[AsCommand(
+    name: 'app:dev:login-link',
+    description: 'Print a one-shot login link for a user (dev environment only)'
+)]
+class DevLoginLinkCommand extends Command
+{
+    public function __construct(
+        // The firewall-aware handler cannot resolve a firewall without a request.
+        #[Autowire(service: 'security.authenticator.login_link_handler.main')]
+        private readonly LoginLinkHandlerInterface $loginLinkHandler,
+        private readonly UserRepository $userRepository,
+        #[Autowire('%kernel.environment%')]
+        private readonly string $environment
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('user', InputArgument::OPTIONAL, 'User id or email', '1')
+            ->addOption('base-url', null, InputOption::VALUE_REQUIRED, 'Host the link should point at', 'https://127.0.0.1:8000');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if ('dev' !== $this->environment) {
+            $io->error(\sprintf('Refusing to run in the "%s" environment.', $this->environment));
+
+            return Command::FAILURE;
+        }
+
+        $identifier = (string) $input->getArgument('user');
+        $user = ctype_digit($identifier)
+            ? $this->userRepository->find((int) $identifier)
+            : $this->userRepository->findOneBy(['email' => $identifier]);
+
+        if (null === $user) {
+            $io->error(\sprintf('No user matching "%s".', $identifier));
+
+            return Command::FAILURE;
+        }
+
+        $link = $this->loginLinkHandler->createLoginLink($user, Request::create((string) $input->getOption('base-url')));
+
+        $io->success(\sprintf('%s (id %d) — link is single-session, expires per login_link config', $user->getEmail(), $user->getId()));
+        $io->writeln($link->getUrl());
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/NotificationPurgeCommand.php
+++ b/src/Command/NotificationPurgeCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Repository\NotificationRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * SendRankingNotifCommand writes one row per user per run and nothing ever
+ * removed them, so the table grew without bound. Read notifications are never
+ * displayed again — only their row cost remains.
+ */
+#[AsCommand(
+    name: 'app:notification:purge',
+    description: 'Delete read notifications older than the retention window'
+)]
+class NotificationPurgeCommand extends Command
+{
+    private const int DEFAULT_RETENTION_DAYS = 90;
+
+    public function __construct(private readonly NotificationRepository $notificationRepository)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('days', null, InputOption::VALUE_REQUIRED, 'Retention window in days', self::DEFAULT_RETENTION_DAYS)
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show what would happen without actually doing it');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $days = (int) $input->getOption('days');
+        if ($days < 1) {
+            $io->error('--days must be a positive integer.');
+
+            return Command::INVALID;
+        }
+
+        $before = new \DateTimeImmutable(\sprintf('-%d days', $days));
+
+        if ($input->getOption('dry-run')) {
+            $io->warning('DRY RUN - No changes will be made.');
+            $io->success(\sprintf('%d read notifications older than %s would be deleted.', $this->notificationRepository->countReadOlderThan($before), $before->format('Y-m-d')));
+
+            return Command::SUCCESS;
+        }
+
+        $deleted = $this->notificationRepository->deleteReadOlderThan($before);
+
+        $io->success(\sprintf('Deleted %d read notifications older than %s.', $deleted, $before->format('Y-m-d')));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -59,11 +59,14 @@ class DefaultController extends BaseController
             $missingImages = $riddenCoasterRepository->findCoastersWithNoImage($user);
         }
 
+        $reviews = $riddenCoasterRepository->getLatestReviews($preferredReviewLanguages, 3);
+        $riddenCoasterRepository->preloadTags($reviews);
+
         return $this->render('Default/index.html.twig', [
             'ratingFeed' => $riddenCoasterRepository->getLatestRatings(6),
             'image' => $imageRepository->findLatestLikedImage(),
             'stats' => $statService->getIndexStats(),
-            'reviews' => $riddenCoasterRepository->getLatestReviews($preferredReviewLanguages, 3),
+            'reviews' => $reviews,
             'missingImages' => $missingImages,
             'preferredReviewLanguages' => $preferredReviewLanguages,
         ]);

--- a/src/Controller/ReviewController.php
+++ b/src/Controller/ReviewController.php
@@ -45,6 +45,7 @@ class ReviewController extends BaseController
         } catch (\UnexpectedValueException) {
             throw new BadRequestHttpException();
         }
+        $riddenCoasterRepository->preloadTags($pagination);
 
         return $this->render(
             'Review/list.html.twig',

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -107,6 +107,7 @@ class UserController extends BaseController
         } catch (\UnexpectedValueException) {
             throw new BadRequestHttpException();
         }
+        $riddenCoasterRepository->preloadTags($pagination);
 
         return $this->render(
             'User/list_reviews.html.twig',

--- a/src/Entity/Coaster.php
+++ b/src/Entity/Coaster.php
@@ -183,7 +183,7 @@ class Coaster implements \Stringable
     private ?int $previousRank = null;
 
     /** @var Collection<int, RiddenCoaster> */
-    #[ORM\OneToMany(targetEntity: RiddenCoaster::class, mappedBy: 'coaster')]
+    #[ORM\OneToMany(targetEntity: RiddenCoaster::class, mappedBy: 'coaster', fetch: 'EXTRA_LAZY')]
     private Collection $ratings;
 
     /** @var Collection<int, MainTag> */
@@ -191,7 +191,7 @@ class Coaster implements \Stringable
     private Collection $mainTags;
 
     /** @var Collection<int, Image> */
-    #[ORM\OneToMany(targetEntity: Image::class, mappedBy: 'coaster')]
+    #[ORM\OneToMany(targetEntity: Image::class, mappedBy: 'coaster', fetch: 'EXTRA_LAZY')]
     private Collection $images;
 
     #[ORM\OneToOne(targetEntity: Image::class, fetch: 'EAGER')]

--- a/src/Entity/Notification.php
+++ b/src/Entity/Notification.php
@@ -13,6 +13,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  * Notification.
  */
 #[ORM\Table(name: 'notification')]
+#[ORM\Index(name: 'idx_notification_user_unread', columns: ['user_id', 'is_read', 'created_at'])]
 #[ORM\Entity(repositoryClass: NotificationRepository::class)]
 class Notification
 {

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -68,27 +68,27 @@ class User implements UserInterface
     private ?string $profilePicture = null;
 
     /** @var Collection<int, RiddenCoaster> */
-    #[ORM\OneToMany(mappedBy: 'user', targetEntity: RiddenCoaster::class)]
+    #[ORM\OneToMany(mappedBy: 'user', targetEntity: RiddenCoaster::class, fetch: 'EXTRA_LAZY')]
     private Collection $ratings;
 
     /** @var Collection<int, Top> */
-    #[ORM\OneToMany(mappedBy: 'user', targetEntity: Top::class)]
+    #[ORM\OneToMany(mappedBy: 'user', targetEntity: Top::class, fetch: 'EXTRA_LAZY')]
     private Collection $tops;
 
     /** @var Collection<int, Badge> */
-    #[ORM\ManyToMany(targetEntity: Badge::class, inversedBy: 'users')]
+    #[ORM\ManyToMany(targetEntity: Badge::class, inversedBy: 'users', fetch: 'EXTRA_LAZY')]
     #[ORM\JoinTable]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     #[ORM\InverseJoinColumn(nullable: false, onDelete: 'RESTRICT')]
     private Collection $badges;
 
     /** @var Collection<int, Notification> */
-    #[ORM\OneToMany(mappedBy: 'user', targetEntity: Notification::class)]
+    #[ORM\OneToMany(mappedBy: 'user', targetEntity: Notification::class, fetch: 'EXTRA_LAZY')]
     #[ORM\OrderBy(['createdAt' => 'DESC'])]
     private Collection $notifications;
 
     /** @var Collection<int, Image> */
-    #[ORM\OneToMany(mappedBy: 'uploader', targetEntity: Image::class, cascade: ['remove'])]
+    #[ORM\OneToMany(mappedBy: 'uploader', targetEntity: Image::class, cascade: ['remove'], fetch: 'EXTRA_LAZY')]
     private Collection $images;
 
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -452,12 +452,6 @@ class User implements UserInterface
         return $this->notifications;
     }
 
-    /** @return Collection<int, Notification> */
-    public function getUnreadNotifications(): Collection
-    {
-        return $this->notifications->filter(static fn (Notification $notif) => !$notif->getIsRead());
-    }
-
     public function isEmailNotification(): bool
     {
         return $this->emailNotification;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -34,6 +34,9 @@ class User implements UserInterface
 
     private const string ROLE_DEFAULT = 'ROLE_USER';
 
+    /** Properties kept out of the serialized session token — see __serialize(). */
+    private const array NOT_SERIALIZED = ['ratings', 'tops', 'badges', 'notifications', 'images', 'homePark'];
+
     #[ORM\Id]
     #[ORM\Column(type: Types::INTEGER)]
     #[ORM\GeneratedValue]
@@ -569,6 +572,43 @@ class User implements UserInterface
 
     public function eraseCredentials(): void
     {
+    }
+
+    /**
+     * Keeps collections and lazy relations out of the security token, which
+     * ContextListener serializes into the Redis session on every response.
+     * The navbar loads every notification of the user, and those used to ride
+     * along: production sessions reached 1.9 MB, read and rewritten on each
+     * request. refreshUser() reloads the entity from the database anyway.
+     *
+     * @return array<string, mixed>
+     */
+    public function __serialize(): array
+    {
+        $data = (array) $this;
+
+        foreach (self::NOT_SERIALIZED as $property) {
+            unset($data["\0".self::class."\0".$property]);
+        }
+
+        return $data;
+    }
+
+    /** @param array<string, mixed> $data */
+    public function __unserialize(array $data): void
+    {
+        foreach ($data as $key => $value) {
+            $position = strrpos((string) $key, "\0");
+            $this->{false === $position ? $key : substr((string) $key, $position + 1)} = $value;
+        }
+
+        // unserialize() skips the constructor, so the excluded collections would
+        // stay uninitialised and fatal on first access.
+        $this->ratings = new ArrayCollection();
+        $this->tops = new ArrayCollection();
+        $this->badges = new ArrayCollection();
+        $this->notifications = new ArrayCollection();
+        $this->images = new ArrayCollection();
     }
 
     /** @return non-empty-string */

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\Notification;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -16,6 +17,58 @@ class NotificationRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Notification::class);
+    }
+
+    /** @return array<int, Notification> */
+    public function findUnreadForUser(User $user, int $limit): array
+    {
+        return $this
+            ->createQueryBuilder('n')
+            ->where('n.user = :user')
+            ->andWhere('n.isRead = false')
+            ->setParameter('user', $user)
+            ->orderBy('n.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function countUnreadForUser(User $user): int
+    {
+        return (int) $this
+            ->createQueryBuilder('n')
+            ->select('COUNT(n.id)')
+            ->where('n.user = :user')
+            ->andWhere('n.isRead = false')
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /** Deletes read notifications created before $before. Returns the number of rows removed. */
+    public function deleteReadOlderThan(\DateTimeInterface $before): int
+    {
+        return $this
+            ->getEntityManager()
+            ->createQueryBuilder()
+            ->delete(Notification::class, 'n')
+            ->where('n.isRead = true')
+            ->andWhere('n.createdAt < :before')
+            ->setParameter('before', $before)
+            ->getQuery()
+            ->execute();
+    }
+
+    public function countReadOlderThan(\DateTimeInterface $before): int
+    {
+        return (int) $this
+            ->createQueryBuilder('n')
+            ->select('COUNT(n.id)')
+            ->where('n.isRead = true')
+            ->andWhere('n.createdAt < :before')
+            ->setParameter('before', $before)
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 
     public function markTypeAsRead(string $type): int

--- a/src/Repository/RiddenCoasterRepository.php
+++ b/src/Repository/RiddenCoasterRepository.php
@@ -358,7 +358,7 @@ class RiddenCoasterRepository extends ServiceEntityRepository
             LEFT JOIN (
                 SELECT rc.coaster_id AS id, COUNT(rc.rating) AS nb
                 FROM ridden_coaster rc
-                INNER JOIN user u ON rc.user_id = u.id
+                INNER JOIN users u ON rc.user_id = u.id
                 WHERE u.enabled = 1
                 GROUP BY rc.coaster_id
             ) c2
@@ -384,7 +384,7 @@ class RiddenCoasterRepository extends ServiceEntityRepository
             LEFT JOIN (
                 SELECT rc.coaster_id AS id, ROUND(AVG(rc.rating), 3) AS average
                 FROM ridden_coaster rc
-                INNER JOIN user u ON rc.user_id = u.id
+                INNER JOIN users u ON rc.user_id = u.id
                 WHERE u.enabled = 1
                 GROUP BY rc.coaster_id
                 HAVING COUNT(rc.rating) >= :minRatings

--- a/src/Repository/RiddenCoasterRepository.php
+++ b/src/Repository/RiddenCoasterRepository.php
@@ -294,6 +294,45 @@ class RiddenCoasterRepository extends ServiceEntityRepository
             ->setParameter('user', $user);
     }
 
+    /**
+     * Initialises the pros/cons collections of the given reviews, two queries total.
+     *
+     * Includes/_review_item.html.twig reads review.pros and review.cons, both lazy
+     * ManyToMany. Without this, rendering N reviews fires 2N collection-loading
+     * queries from inside Twig — invisible in the template's own timing, and the
+     * shape production's FPM slowlog caught at over a second.
+     *
+     * Not needed for getCoasterReviews(), which already fetch-joins both.
+     *
+     * @param iterable<mixed> $reviews
+     */
+    public function preloadTags(iterable $reviews): void
+    {
+        $ids = [];
+        foreach ($reviews as $review) {
+            if ($review instanceof RiddenCoaster) {
+                $ids[] = $review->getId();
+            }
+        }
+
+        if ([] === $ids) {
+            return;
+        }
+
+        // Two separate queries on purpose: joining both ManyToMany at once
+        // multiplies rows into a cartesian product.
+        foreach (['pros', 'cons'] as $association) {
+            $this
+                ->createQueryBuilder('r')
+                ->select('r', 't')
+                ->leftJoin('r.'.$association, 't')
+                ->where('r.id IN (:ids)')
+                ->setParameter('ids', $ids)
+                ->getQuery()
+                ->getResult();
+        }
+    }
+
     /** @return QueryBuilder */
     public function getUserReviews(User $user)
     {

--- a/src/Twig/NotificationExtension.php
+++ b/src/Twig/NotificationExtension.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig;
+
+use App\Entity\Notification;
+use App\Entity\User;
+use App\Repository\NotificationRepository;
+use Symfony\Bundle\SecurityBundle\Security;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Feeds the navbar notification dropdown with bounded queries.
+ *
+ * User::getUnreadNotifications() used to filter the notifications collection in
+ * PHP, so Doctrine loaded every notification the user ever received — read ones
+ * included — on every page render, and they then rode along in the serialized
+ * session token.
+ */
+class NotificationExtension extends AbstractExtension
+{
+    private const int DROPDOWN_LIMIT = 3;
+
+    public function __construct(
+        private readonly NotificationRepository $notificationRepository,
+        private readonly Security $security
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('unread_notifications', $this->unreadNotifications(...)),
+            new TwigFunction('unread_notification_count', $this->unreadNotificationCount(...)),
+        ];
+    }
+
+    /** @return array<int, Notification> */
+    public function unreadNotifications(): array
+    {
+        $user = $this->security->getUser();
+
+        return $user instanceof User
+            ? $this->notificationRepository->findUnreadForUser($user, self::DROPDOWN_LIMIT)
+            : [];
+    }
+
+    public function unreadNotificationCount(): int
+    {
+        $user = $this->security->getUser();
+
+        return $user instanceof User ? $this->notificationRepository->countUnreadForUser($user) : 0;
+    }
+}

--- a/templates/Coaster/_image_panel.html.twig
+++ b/templates/Coaster/_image_panel.html.twig
@@ -1,10 +1,11 @@
+{% set image_count = coaster.images|length %}
 <div class="panel panel-flat">
     <div class="panel-heading">
         <h6 class="panel-title">
             <span class="text-semibold">
                 {{ ux_icon('heroicons:photo', {'class': 'w-6 h-6 position-left'}) }} {{ 'coaster.photos.title'|trans }}
-                {% if coaster.images|length > 0 %}
-                    <span class="badge badge-primary">{{ coaster.images|length }}</span>
+                {% if image_count > 0 %}
+                    <span class="badge badge-primary">{{ image_count }}</span>
                 {% endif %}
             </span>
         </h6>
@@ -15,7 +16,7 @@
           </div>
     </div>
     
-    {% if coaster.images|length > 0 %}
+    {% if image_count > 0 %}
         <div class="panel-body" 
              data-controller="gallery" 
              data-gallery-name-value="coaster-images"
@@ -45,7 +46,7 @@
                 </div>
             {% endfor %}
         </div>
-        {% if number < coaster.images|length %}
+        {% if number < image_count %}
             <div class="panel-footer text-center">
                 <a id="show-all" class="btn btn-link">{{ 'coaster.photos.all'|trans }}</a>
             </div>

--- a/templates/Coaster/rating-json-ld.html.twig
+++ b/templates/Coaster/rating-json-ld.html.twig
@@ -11,7 +11,10 @@
       "ratingValue": "{{ (coaster.score * 5 / 100)|number_format(1, '.') }}",
       "bestRating": "5",
       "worstRating": "0",
-      "ratingCount": "{{ coaster.ratings|length }}"
+      {# totalRatings, not ratings|length: the collection is a plain OneToMany, so |length hydrates
+         every RiddenCoaster of the coaster (4,000+ entities, ~280ms) to print one number. The
+         denormalised column is also the more correct value — it counts ratings, not rides. #}
+      "ratingCount": "{{ coaster.totalRatings }}"
     }
   }
         </script>

--- a/templates/navbar.html.twig
+++ b/templates/navbar.html.twig
@@ -57,13 +57,14 @@
             </li>
             <li class="divider"></li>
             <!-- notifications -->
+            {% set unread_count = unread_notification_count() %}
             <li class="dropdown-submenu dropdown-submenu-hover dropdown-submenu-left">
               <a href="#" class="dropdown-toggle account-menu-row" data-toggle="dropdown">
                 <span class="account-menu-row-label">
                   {{ ux_icon('heroicons:bell', {'class': 'w-5 h-5'}) }}
                   {{ 'notif.title'|trans }}
-                  {% if app.user.unreadNotifications|length > 0 %}
-                    <span class="badge bg-warning-400">{{ app.user.unreadNotifications|length }}</span>
+                  {% if unread_count > 0 %}
+                    <span class="badge bg-warning-400">{{ unread_count }}</span>
                   {% endif %}
                 </span>
                 <span class="account-menu-row-value">
@@ -73,7 +74,7 @@
               <div class="dropdown-menu dropdown-content">
                 <div class="dropdown-content-heading">{{ 'notif.title'|trans }}</div>
                 <ul class="media-list dropdown-content-body width-350">
-                  {% for notif in app.user.unreadNotifications %}
+                  {% for notif in unread_notifications() %}
                     <li class="media">
                       <div class="media-left">
                         <a href="#" class="btn bg-success-400 btn-rounded btn-icon btn-xs">

--- a/tests/Entity/UserSerializationTest.php
+++ b/tests/Entity/UserSerializationTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\Notification;
+use App\Entity\User;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
+
+/**
+ * The security token is serialized into the Redis session on every response
+ * (ContextListener::onKernelResponse). Without a narrowed __serialize(), the
+ * whole User object graph goes with it — production sessions reached 1.9 MB.
+ */
+final class UserSerializationTest extends TestCase
+{
+    private const int MAX_TOKEN_BYTES = 4096;
+
+    public function testSessionTokenStaysSmallWhenCollectionsAreLoaded(): void
+    {
+        $token = new RememberMeToken($this->userWithNotifications(1000), 'main');
+
+        $this->assertLessThan(
+            self::MAX_TOKEN_BYTES,
+            \strlen(serialize($token)),
+            'Loaded collections must not end up in the session token.'
+        );
+    }
+
+    public function testLoadedCollectionsDoNotAppearInTheBlob(): void
+    {
+        $blob = serialize(new RememberMeToken($this->userWithNotifications(10), 'main'));
+
+        $this->assertFalse(
+            str_contains($blob, Notification::class),
+            'The session token still carries Notification entities.'
+        );
+    }
+
+    /** Fields ContextListener and AbstractToken::hasUserChanged() rely on: a mismatch logs everyone out. */
+    #[DataProvider('securityCriticalFields')]
+    public function testRoundTripPreservesSecurityCriticalField(string $getter): void
+    {
+        $user = $this->userWithNotifications(5);
+
+        /** @var User $restored */
+        $restored = unserialize(serialize($user));
+
+        $this->assertSame($user->$getter(), $restored->$getter());
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function securityCriticalFields(): iterable
+    {
+        yield 'id' => ['getId'];
+        yield 'user identifier' => ['getUserIdentifier'];
+        yield 'enabled' => ['isEnabled'];
+        yield 'deleted at' => ['getDeletedAt'];
+    }
+
+    public function testRoundTripPreservesRoles(): void
+    {
+        $user = $this->userWithNotifications(5);
+        $user->setRoles(['ROLE_ADMIN']);
+
+        /** @var User $restored */
+        $restored = unserialize(serialize($user));
+
+        $this->assertSame($user->getRoles(), $restored->getRoles());
+    }
+
+    /** unserialize() skips the constructor, so the collections must be re-initialised by hand. */
+    public function testRestoredCollectionsAreUsableAndEmpty(): void
+    {
+        /** @var User $restored */
+        $restored = unserialize(serialize($this->userWithNotifications(5)));
+
+        $this->assertCount(0, $restored->getNotifications());
+        $this->assertCount(0, $restored->getRatings());
+        $this->assertCount(0, $restored->getTops());
+        $this->assertCount(0, $restored->getBadges());
+        $this->assertCount(0, $restored->getImages());
+    }
+
+    /**
+     * Sessions written before __serialize() existed still hold the full object
+     * graph. PHP hands that whole array to __unserialize(), which must cope
+     * with it rather than fatal — those sessions heal on their next write.
+     */
+    public function testLegacySessionPayloadIsAccepted(): void
+    {
+        $user = $this->userWithNotifications(5);
+        $legacyPayload = (array) $user;
+
+        $restored = new User();
+        $restored->__unserialize($legacyPayload);
+
+        $this->assertSame($user->getUserIdentifier(), $restored->getUserIdentifier());
+        $this->assertCount(0, $restored->getNotifications());
+    }
+
+    private function userWithNotifications(int $count): User
+    {
+        $user = new User();
+        $user->setEmail('rider@example.com');
+        $user->setDisplayName('Rider');
+        $user->setSlug('rider');
+
+        for ($i = 0; $i < $count; ++$i) {
+            $notification = new Notification();
+            $notification->setUser($user);
+            $notification->setMessage('notif.ranking.messageWithNewCoaster');
+            $notification->setParameter('Blue Fire Megacoaster');
+            $notification->setType('ranking');
+            $notification->setIsRead(true);
+            $notification->setCreatedAt(new \DateTime());
+
+            $user->addNotification($notification);
+        }
+
+        return $user;
+    }
+}


### PR DESCRIPTION
Six fixes for logged-in latency, found by measuring against a production dump locally, plus one dev tool. Each commit carries its own measurement.

**This does not close the Blue Fire incident.** `summary/ajax` renders no reviews and loads no collection — none of these fixes touch it, and PSI ruled out the machine being resource-bound (`io some avg300=0.07`, 51-94% idle CPU). That thread stays open.

## What changed

| | measured |
|---|---|
| `User::__serialize()` keeps collections out of the session token | Redis session 1.93 MB → **2,217 bytes** |
| `EXTRA_LAZY` on collections that templates only count | profile page 258ms → **61ms**, 42.0 → **30.0 MiB** |
| `user` → `users` in the denormalised counter queries | `total_ratings` 3,509 → **4,221** |
| JSON-LD reads `totalRatings` instead of hydrating every rating | **277ms** of hydration removed on blue fire |
| `preloadTags()` on the three review queries lacking the join | `/users/1/reviews` 50 → **24** queries |
| Navbar unread notifications bounded + covering index | exact count, 3 rows, `Using index` |

The session blob and the `|length` hydration were both invisible to the Symfony profiler by construction: raw session reads carry no Stopwatch section, and the Doctrine panel times query execution, not ORM hydration. Production's FPM slowlog at `request_slowlog_timeout = 1s` is what surfaced them.

## Reviewer notes

- **`averageRating` and `total_ratings` will visibly shift.** Both have been frozen since the `user` → `users` rename; the stats cron will recompute them and displayed ratings across the site will move. This is the only user-visible data change here.
- `EXTRA_LAZY` changes `count()`, `contains()` and `clear()` into queries. Audited: `BannerService` and `ReviewScoreService` improve for free (both did `->count()` on the ratings collection), `AccountDeletionService`'s `getBadges()->clear()` is unaffected — `clear()` has no extra-lazy branch in `PersistentCollection`, so it still schedules the join-table `DELETE` into the same `flush()` transaction. Iteration is unchanged everywhere.
- `getCoasterReviews()` already fetch-joins pros and cons and is deliberately left alone — its triple join returns 6,864 rows against 4,224 base rows on blue fire, which is worth revisiting separately with a production measurement rather than churning what #355 just tuned.
- Sessions written before this heal on their next write; no flush needed, covered by a test.

## Deploy

1. `SELECT COUNT(*) FROM notification;` before migrating — index creation is online on MariaDB 11.8, but this table has never been purged.
2. Deploy, then `redis-cli --scan --pattern '*sitemap*'` and `DEL` — the 14.5 MB key is orphaned once the pool is on the filesystem.
3. `app:stats:update` to unfreeze the counters.
4. Re-scan `sf_s*` after an hour to confirm session blobs collapsed.
5. Optionally schedule `app:notification:purge --days=90`.
