### PR TITLE
fix: coaster summary regeneratedAt NULL crash + Discord alert noise

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -46,7 +46,7 @@ when@prod:
                 type: fingers_crossed
                 action_level: error
                 handler: main_grouped
-                excluded_http_codes: [404, 405]
+                excluded_http_codes: [400, 401, 404, 405]
                 buffer_size: 50 # How many messages should be saved? Prevent memory leaks
                 channels: ['!event', '!deprecation', '!moderation']
             moderation:

--- a/src/Service/CoasterSummaryService.php
+++ b/src/Service/CoasterSummaryService.php
@@ -106,6 +106,11 @@ class CoasterSummaryService
         $summary->setLanguage($language);
         $summary->setAiModel($analysis['result']['resolvedModelKey']);
 
+        // Gedmo's on:'change' strategy only updates existing rows, not new inserts
+        if (null === $summary->getId()) {
+            $summary->setRegeneratedAt(new \DateTime());
+        }
+
         // Reset votes when summary is regenerated since content has changed
         $summary->setPositiveVotes(0);
         $summary->setNegativeVotes(0);


### PR DESCRIPTION
## Summary
- Fix `NotNullConstraintViolationException` on `coaster_summary.regenerated_at`: Gedmo's `on: 'change'` tracking strategy only fires on updates, never on the first INSERT, so the first-ever summary per coaster/language crashed `GenerateCoasterSummariesCommand`. Now set explicitly when the entity has no id yet.
- Exclude `400`/`401` from Discord error alerts: `BadRequestHttpException` and now-routine `401`s (since `/api` requires `ROLE_ADMIN`) were flooding the channel with one unlabeled message per request. Extends the existing `excluded_http_codes` pattern already used for `404`/`405`; app-level `logger->error()`/`critical()` calls are unaffected.

## Test plan
- [x] `vendor/bin/phpunit` — 245 tests pass
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/php-cs-fixer fix --dry-run` — clean
- [x] `bin/console lint:container` — clean