### PR TITLE
feat(admin): introduce Contributor/Moderator/Admin permission tiers

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -54,7 +54,7 @@ security:
 
     role_hierarchy:
         ROLE_MODERATOR: [ROLE_CONTRIBUTOR]
-        ROLE_ADMIN: [ROLE_USER, ROLE_MODERATOR]
+        ROLE_ADMIN: [ROLE_MODERATOR]
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -53,8 +53,8 @@ security:
                 httponly: true
 
     role_hierarchy:
-        ROLE_ADMIN: [ROLE_USER, ROLE_CONTRIBUTOR, ROLE_PREVIEW_FEATURE]
-        ROLE_SUPER_ADMIN: ROLE_ADMIN
+        ROLE_MODERATOR: [ROLE_CONTRIBUTOR]
+        ROLE_ADMIN: [ROLE_USER, ROLE_MODERATOR]
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:

--- a/migrations/Version20260903120000.php
+++ b/migrations/Version20260903120000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260903120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Migrate admin roles to the new Contributor/Moderator/Admin hierarchy: ROLE_SUPER_ADMIN becomes ROLE_ADMIN, former ROLE_ADMIN becomes ROLE_MODERATOR';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // JSON_SEARCH (rather than JSON_CONTAINS) because a few rows have `roles` stored
+        // as a JSON object with non-sequential keys instead of a plain array.
+        $this->addSql('UPDATE users SET roles = \'["ROLE_MODERATOR"]\' WHERE JSON_SEARCH(roles, \'one\', \'ROLE_ADMIN\') IS NOT NULL');
+        $this->addSql('UPDATE users SET roles = \'["ROLE_ADMIN"]\' WHERE JSON_SEARCH(roles, \'one\', \'ROLE_SUPER_ADMIN\') IS NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('UPDATE users SET roles = \'["ROLE_SUPER_ADMIN"]\' WHERE JSON_SEARCH(roles, \'one\', \'ROLE_ADMIN\') IS NOT NULL');
+        $this->addSql('UPDATE users SET roles = \'["ROLE_ADMIN"]\' WHERE JSON_SEARCH(roles, \'one\', \'ROLE_MODERATOR\') IS NOT NULL');
+    }
+}

--- a/migrations/Version20260903120000.php
+++ b/migrations/Version20260903120000.php
@@ -18,13 +18,26 @@ final class Version20260903120000 extends AbstractMigration
     {
         // JSON_SEARCH (rather than JSON_CONTAINS) because a few rows have `roles` stored
         // as a JSON object with non-sequential keys instead of a plain array.
-        $this->addSql('UPDATE users SET roles = \'["ROLE_MODERATOR"]\' WHERE JSON_SEARCH(roles, \'one\', \'ROLE_ADMIN\') IS NOT NULL');
-        $this->addSql('UPDATE users SET roles = \'["ROLE_ADMIN"]\' WHERE JSON_SEARCH(roles, \'one\', \'ROLE_SUPER_ADMIN\') IS NOT NULL');
+        // Single UPDATE with CASE WHEN, checked against the pre-update value, so a row
+        // holding both ROLE_ADMIN and ROLE_SUPER_ADMIN isn't collapsed to ROLE_MODERATOR
+        // by an earlier statement before the ROLE_SUPER_ADMIN branch can match it.
+        $this->addSql(
+            'UPDATE users SET roles = CASE '
+            .'WHEN JSON_SEARCH(roles, \'one\', \'ROLE_SUPER_ADMIN\') IS NOT NULL THEN \'["ROLE_ADMIN"]\' '
+            .'WHEN JSON_SEARCH(roles, \'one\', \'ROLE_ADMIN\') IS NOT NULL THEN \'["ROLE_MODERATOR"]\' '
+            .'ELSE roles END '
+            .'WHERE JSON_SEARCH(roles, \'one\', \'ROLE_ADMIN\') IS NOT NULL OR JSON_SEARCH(roles, \'one\', \'ROLE_SUPER_ADMIN\') IS NOT NULL'
+        );
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('UPDATE users SET roles = \'["ROLE_SUPER_ADMIN"]\' WHERE JSON_SEARCH(roles, \'one\', \'ROLE_ADMIN\') IS NOT NULL');
-        $this->addSql('UPDATE users SET roles = \'["ROLE_ADMIN"]\' WHERE JSON_SEARCH(roles, \'one\', \'ROLE_MODERATOR\') IS NOT NULL');
+        $this->addSql(
+            'UPDATE users SET roles = CASE '
+            .'WHEN JSON_SEARCH(roles, \'one\', \'ROLE_ADMIN\') IS NOT NULL THEN \'["ROLE_SUPER_ADMIN"]\' '
+            .'WHEN JSON_SEARCH(roles, \'one\', \'ROLE_MODERATOR\') IS NOT NULL THEN \'["ROLE_ADMIN"]\' '
+            .'ELSE roles END '
+            .'WHERE JSON_SEARCH(roles, \'one\', \'ROLE_ADMIN\') IS NOT NULL OR JSON_SEARCH(roles, \'one\', \'ROLE_MODERATOR\') IS NOT NULL'
+        );
     }
 }

--- a/src/Controller/Admin/CoasterCrudController.php
+++ b/src/Controller/Admin/CoasterCrudController.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Controller\Admin;
 
 use App\Entity\Coaster;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
@@ -37,6 +39,11 @@ class CoasterCrudController extends AbstractCrudController
             ->setDefaultSort(['updatedAt' => 'DESC'])
             ->showEntityActionsInlined()
             ->setPaginatorPageSize(50);
+    }
+
+    public function configureActions(Actions $actions): Actions
+    {
+        return $actions->setPermission(Action::DELETE, 'ROLE_ADMIN');
     }
 
     public function configureFilters(Filters $filters): Filters

--- a/src/Controller/Admin/CoasterSummaryCrudController.php
+++ b/src/Controller/Admin/CoasterSummaryCrudController.php
@@ -28,15 +28,22 @@ use EasyCorp\Bundle\EasyAdminBundle\Filter\TextFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<CoasterSummary>
  */
+#[IsGranted('ROLE_MODERATOR')]
 class CoasterSummaryCrudController extends AbstractCrudController
 {
+    private const CSRF_TOKEN_ID = 'coaster_summary_regenerate';
+
     public function __construct(
         private readonly CoasterSummaryService $coasterSummaryService,
-        private readonly AdminUrlGenerator $adminUrlGenerator
+        private readonly AdminUrlGenerator $adminUrlGenerator,
+        private readonly CsrfTokenManagerInterface $csrfTokenManager,
     ) {
     }
 
@@ -59,7 +66,13 @@ class CoasterSummaryCrudController extends AbstractCrudController
     public function configureActions(Actions $actions): Actions
     {
         $regenerateAction = Action::new('regenerate', 'Regenerate', 'fas fa-sync-alt')
-            ->linkToCrudAction('regenerateSummary')
+            ->linkToUrl(fn (CoasterSummary $summary): string => $this->adminUrlGenerator
+                ->setController(self::class)
+                ->setAction('regenerateSummary')
+                ->setEntityId($summary->getId())
+                ->set('token', $this->csrfTokenManager->getToken(self::CSRF_TOKEN_ID)->getValue())
+                ->generateUrl())
+            ->renderAsForm()
             ->setCssClass('btn btn-warning btn-sm')
             ->displayIf(static fn (CoasterSummary $summary): bool => null !== $summary->getCoaster());
 
@@ -67,8 +80,7 @@ class CoasterSummaryCrudController extends AbstractCrudController
             ->add(Crud::PAGE_INDEX, $regenerateAction)
             ->add(Crud::PAGE_DETAIL, $regenerateAction)
             ->add(Crud::PAGE_INDEX, Action::DETAIL)
-            ->update(Crud::PAGE_INDEX, Action::DELETE, static fn (Action $action) => $action)
-            ->update(Crud::PAGE_DETAIL, Action::DELETE, static fn (Action $action) => $action)
+            ->setPermission(Action::DELETE, 'ROLE_ADMIN')
             ->disable(Action::NEW)
             ->disable(Action::EDIT);
     }
@@ -145,6 +157,10 @@ class CoasterSummaryCrudController extends AbstractCrudController
 
     public function regenerateSummary(AdminContext $context): Response
     {
+        if (!$this->isCsrfTokenValid(self::CSRF_TOKEN_ID, $context->getRequest()->query->get('token'))) {
+            throw new InvalidCsrfTokenException();
+        }
+
         /** @var CoasterSummary $summary */
         $summary = $context->getEntity()->getInstance();
 

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -58,25 +58,33 @@ class DashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         // yield MenuItem::linkToDashboard('Dashboard', 'fa fa-dashboard');
-        yield MenuItem::linkToCrud('Coaster', 'fas fa-sleigh', Coaster::class);
-        yield MenuItem::linkToCrud('AI Summaries', 'fas fa-robot', CoasterSummary::class);
-        yield MenuItem::linkToCrud('Continent', 'fa fa-globe', Continent::class);
-        yield MenuItem::linkToCrud('Country', 'fa fa-flag-usa', Country::class);
-        yield MenuItem::linkToCrud('Currency', 'fa fa-euro-sign', Currency::class);
-        yield MenuItem::linkToCrud('Pictures', 'fas fa-image', Image::class);
-        yield MenuItem::linkToCrud('Launch', 'fas fa-wind', Launch::class);
-        yield MenuItem::linkToCrud('Manufacturer', 'fas fa-industry', Manufacturer::class);
-        yield MenuItem::linkToCrud('Material Type', 'fas fa-cubes', MaterialType::class);
-        yield MenuItem::linkToCrud('Model', 'fas fa-copyright', Model::class);
-        yield MenuItem::linkToCrud('Park', 'fas fa-dharmachakra', Park::class);
-        yield MenuItem::linkToCrud('Ranking History', 'fas fa-trophy', RankingHistory::class);
-        yield MenuItem::linkToCrud('Restraint', 'fas fa-lock', Restraint::class);
-        yield MenuItem::linkToCrud('Review', 'fa fa-comment-dots', RiddenCoaster::class);
-        yield MenuItem::linkToCrud('Review Reports', 'fa fa-flag', ReviewReport::class);
-        yield MenuItem::linkToCrud('Seating Type', 'fa fa-chair', SeatingType::class);
-        yield MenuItem::linkToCrud('Status', 'fa fa-toggle-on', Status::class);
-        yield MenuItem::linkToCrud('Tag', 'fa fa-tag', Tag::class);
-        yield MenuItem::linkToCrud('Top', 'fa fa-list-ol', Top::class);
-        yield MenuItem::linkToCrud('User', 'fas fa-users', User::class);
+        yield MenuItem::subMenu('Content', 'fas fa-sleigh')->setSubItems([
+            MenuItem::linkToCrud('Coaster', 'fas fa-sleigh', Coaster::class),
+            MenuItem::linkToCrud('Park', 'fas fa-dharmachakra', Park::class),
+            MenuItem::linkToCrud('Manufacturer', 'fas fa-industry', Manufacturer::class),
+            MenuItem::linkToCrud('Model', 'fas fa-copyright', Model::class),
+            MenuItem::linkToCrud('Material Type', 'fas fa-cubes', MaterialType::class),
+            MenuItem::linkToCrud('Launch', 'fas fa-wind', Launch::class),
+            MenuItem::linkToCrud('Restraint', 'fas fa-lock', Restraint::class),
+            MenuItem::linkToCrud('Seating Type', 'fa fa-chair', SeatingType::class),
+            MenuItem::linkToCrud('Status', 'fa fa-toggle-on', Status::class),
+            MenuItem::linkToCrud('Continent', 'fa fa-globe', Continent::class),
+            MenuItem::linkToCrud('Country', 'fa fa-flag-usa', Country::class),
+            MenuItem::linkToCrud('Currency', 'fa fa-euro-sign', Currency::class),
+            MenuItem::linkToCrud('Pictures', 'fas fa-image', Image::class),
+        ]);
+
+        yield MenuItem::subMenu('Moderation', 'fa fa-shield-alt')->setPermission('ROLE_MODERATOR')->setSubItems([
+            MenuItem::linkToCrud('User', 'fas fa-users', User::class),
+            MenuItem::linkToCrud('Review', 'fa fa-comment-dots', RiddenCoaster::class),
+            MenuItem::linkToCrud('Reports', 'fa fa-flag', ReviewReport::class),
+            MenuItem::linkToCrud('Tag', 'fa fa-tag', Tag::class),
+            MenuItem::linkToCrud('AI Summaries', 'fas fa-robot', CoasterSummary::class),
+        ]);
+
+        yield MenuItem::subMenu('Administration', 'fa fa-user-shield')->setPermission('ROLE_ADMIN')->setSubItems([
+            MenuItem::linkToCrud('Top', 'fa fa-list-ol', Top::class),
+            MenuItem::linkToCrud('Ranking History', 'fas fa-trophy', RankingHistory::class),
+        ]);
     }
 }

--- a/src/Controller/Admin/ImageCrudController.php
+++ b/src/Controller/Admin/ImageCrudController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller\Admin;
 
 use App\Entity\Image;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
@@ -48,7 +49,9 @@ class ImageCrudController extends AbstractCrudController
 
     public function configureActions(Actions $actions): Actions
     {
-        return $actions->disable('new');
+        return $actions
+            ->disable('new')
+            ->setPermission(Action::DELETE, 'ROLE_ADMIN');
     }
 
     public function configureFilters(Filters $filters): Filters

--- a/src/Controller/Admin/RankingHistoryCrudController.php
+++ b/src/Controller/Admin/RankingHistoryCrudController.php
@@ -16,10 +16,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\NumberField;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\DateTimeFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<RankingHistory>
  */
+#[IsGranted('ROLE_ADMIN')]
 class RankingHistoryCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/ReviewCrudController.php
+++ b/src/Controller/Admin/ReviewCrudController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller\Admin;
 
 use App\Entity\RiddenCoaster;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
@@ -18,10 +19,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\NumberField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<RiddenCoaster>
  */
+#[IsGranted('ROLE_MODERATOR')]
 class ReviewCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string
@@ -51,7 +54,8 @@ class ReviewCrudController extends AbstractCrudController
     public function configureActions(Actions $actions): Actions
     {
         return $actions
-            ->disable('new');
+            ->disable('new')
+            ->setPermission(Action::DELETE, 'ROLE_ADMIN');
     }
 
     public function configureFields(string $pageName): iterable

--- a/src/Controller/Admin/ReviewReportCrudController.php
+++ b/src/Controller/Admin/ReviewReportCrudController.php
@@ -25,18 +25,34 @@ use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<ReviewReport>
  */
+#[IsGranted('ROLE_MODERATOR')]
 class ReviewReportCrudController extends AbstractCrudController
 {
+    private const CSRF_TOKEN_ID = 'review_report_moderation';
+
     public function __construct(
         private readonly AdminUrlGenerator $adminUrlGenerator,
         private readonly EntityManagerInterface $entityManager,
-        private readonly ReviewReportRepository $reportRepository
+        private readonly ReviewReportRepository $reportRepository,
+        private readonly CsrfTokenManagerInterface $csrfTokenManager,
     ) {
+    }
+
+    private function actionUrl(int $entityId, string $crudAction): string
+    {
+        return $this->adminUrlGenerator
+            ->setController(self::class)
+            ->setAction($crudAction)
+            ->setEntityId($entityId)
+            ->set('token', $this->csrfTokenManager->getToken(self::CSRF_TOKEN_ID)->getValue())
+            ->generateUrl();
     }
 
     public static function getEntityFqcn(): string
@@ -47,8 +63,8 @@ class ReviewReportCrudController extends AbstractCrudController
     public function configureCrud(Crud $crud): Crud
     {
         return $crud
-            ->setEntityLabelInSingular('Review Report')
-            ->setEntityLabelInPlural('Review Reports')
+            ->setEntityLabelInSingular('Report')
+            ->setEntityLabelInPlural('Reports')
             ->setSearchFields(['id', 'user.displayName', 'reviewContent', 'reason'])
             ->setDefaultSort(['resolved' => 'ASC', 'createdAt' => 'DESC'])
             ->showEntityActionsInlined()
@@ -78,34 +94,35 @@ class ReviewReportCrudController extends AbstractCrudController
                 ->addCssClass('text-info')
         );
 
-        // Add admin-only actions
-        if ($this->isGranted('ROLE_ADMIN')) {
-            $moderationActions
-                ->addAction(
-                    Action::new('deleteReview', 'Delete Review', 'fa fa-trash')
-                        ->linkToCrudAction('deleteReviewAction')
-                        ->addCssClass('text-danger')
-                        ->displayIf(static fn ($entity) => null !== $entity->getReview())
-                )
-                ->addAction(
-                    Action::new('clearReviewText', 'Clear Review Text', 'fa fa-eraser')
-                        ->linkToCrudAction('clearReviewTextAction')
-                        ->addCssClass('text-warning')
-                        ->displayIf(static fn ($entity) => null !== $entity->getReview() && null !== $entity->getReview()->getReview())
-                )
-                ->addAction(
-                    Action::new('disableUser', 'Ban User', 'fa fa-user-slash')
-                        ->linkToCrudAction('disableUserAction')
-                        ->addCssClass('text-warning')
-                );
-        }
-
-        // Add action available to all moderators
-        $moderationActions->addAction(
-            Action::new('doNothing', 'No Action', 'fa fa-check')
-                ->linkToCrudAction('doNothingAction')
-                ->addCssClass('text-success')
-        );
+        // Moderation actions: writes need POST + CSRF token since they're reached via
+        // a dropdown link, not a real form submission (see actionUrl()).
+        $moderationActions
+            ->addAction(
+                Action::new('deleteReview', 'Delete Review', 'fa fa-trash')
+                    ->linkToUrl(fn ($entity) => $this->actionUrl($entity->getId(), 'deleteReviewAction'))
+                    ->renderAsForm()
+                    ->addCssClass('text-danger')
+                    ->displayIf(static fn ($entity) => null !== $entity->getReview())
+            )
+            ->addAction(
+                Action::new('clearReviewText', 'Clear Review Text', 'fa fa-eraser')
+                    ->linkToUrl(fn ($entity) => $this->actionUrl($entity->getId(), 'clearReviewTextAction'))
+                    ->renderAsForm()
+                    ->addCssClass('text-warning')
+                    ->displayIf(static fn ($entity) => null !== $entity->getReview() && null !== $entity->getReview()->getReview())
+            )
+            ->addAction(
+                Action::new('disableUser', 'Ban User', 'fa fa-user-slash')
+                    ->linkToUrl(fn ($entity) => $this->actionUrl($entity->getId(), 'disableUserAction'))
+                    ->renderAsForm()
+                    ->addCssClass('text-warning')
+            )
+            ->addAction(
+                Action::new('doNothing', 'No Action', 'fa fa-check')
+                    ->linkToUrl(fn ($entity) => $this->actionUrl($entity->getId(), 'doNothingAction'))
+                    ->renderAsForm()
+                    ->addCssClass('text-success')
+            );
 
         // Create actions dropdown for processed reports
         $processedActions = ActionGroup::new('processed', 'Actions')
@@ -267,9 +284,12 @@ class ReviewReportCrudController extends AbstractCrudController
         return $fields;
     }
 
-    #[IsGranted('ROLE_ADMIN')]
     public function deleteReviewAction(AdminContext $context): Response
     {
+        if (!$this->isCsrfTokenValid(self::CSRF_TOKEN_ID, $context->getRequest()->query->get('token'))) {
+            throw new InvalidCsrfTokenException();
+        }
+
         /** @var ReviewReport $contextReport */
         $contextReport = $context->getEntity()->getInstance();
 
@@ -318,9 +338,12 @@ class ReviewReportCrudController extends AbstractCrudController
         return $this->redirectToIndex();
     }
 
-    #[IsGranted('ROLE_ADMIN')]
     public function clearReviewTextAction(AdminContext $context): Response
     {
+        if (!$this->isCsrfTokenValid(self::CSRF_TOKEN_ID, $context->getRequest()->query->get('token'))) {
+            throw new InvalidCsrfTokenException();
+        }
+
         /** @var ReviewReport $contextReport */
         $contextReport = $context->getEntity()->getInstance();
 
@@ -369,9 +392,12 @@ class ReviewReportCrudController extends AbstractCrudController
         return $this->redirectToIndex();
     }
 
-    #[IsGranted('ROLE_ADMIN')]
     public function disableUserAction(AdminContext $context): Response
     {
+        if (!$this->isCsrfTokenValid(self::CSRF_TOKEN_ID, $context->getRequest()->query->get('token'))) {
+            throw new InvalidCsrfTokenException();
+        }
+
         /** @var ReviewReport $contextReport */
         $contextReport = $context->getEntity()->getInstance();
 
@@ -418,6 +444,10 @@ class ReviewReportCrudController extends AbstractCrudController
 
     public function doNothingAction(AdminContext $context): Response
     {
+        if (!$this->isCsrfTokenValid(self::CSRF_TOKEN_ID, $context->getRequest()->query->get('token'))) {
+            throw new InvalidCsrfTokenException();
+        }
+
         /** @var ReviewReport $contextReport */
         $contextReport = $context->getEntity()->getInstance();
 

--- a/src/Controller/Admin/TagCrudController.php
+++ b/src/Controller/Admin/TagCrudController.php
@@ -11,10 +11,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<Tag>
  */
+#[IsGranted('ROLE_MODERATOR')]
 class TagCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/TopCrudController.php
+++ b/src/Controller/Admin/TopCrudController.php
@@ -15,10 +15,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<Top>
  */
+#[IsGranted('ROLE_ADMIN')]
 class TopCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -10,7 +10,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
-use EasyCorp\Bundle\EasyAdminBundle\Field\ArrayField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
@@ -19,10 +18,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<User>
  */
+#[IsGranted('ROLE_MODERATOR')]
 class UserCrudController extends AbstractCrudController
 {
     /** @param array<string> $locales */
@@ -107,7 +108,15 @@ class UserCrudController extends AbstractCrudController
 
         // Edit page - Access
         yield FormField::addPanel('Access')->onlyOnForms();
-        yield ArrayField::new('roles')->onlyOnForms()->setPermission('ROLE_SUPER_ADMIN');
+        yield ChoiceField::new('roles')
+            ->setChoices([
+                'Contributor' => 'ROLE_CONTRIBUTOR',
+                'Moderator' => 'ROLE_MODERATOR',
+                'Admin' => 'ROLE_ADMIN',
+            ])
+            ->allowMultipleChoices()
+            ->onlyOnForms()
+            ->setPermission('ROLE_ADMIN');
         yield TextField::new('apiKey')->onlyOnForms()->setFormTypeOption('disabled', true);
         yield TextField::new('ipAddress')->onlyOnForms()->setFormTypeOption('disabled', true);
 


### PR DESCRIPTION
## Summary
- Replaces the flat admin access model (`ROLE_CONTRIBUTOR`/`ROLE_ADMIN`/`ROLE_SUPER_ADMIN`) with a hierarchy: `ROLE_ADMIN > ROLE_MODERATOR > ROLE_CONTRIBUTOR`.
  - **Contributor**: create/edit catalog content (coasters, parks, vocabulary) — no delete.
  - **Moderator**: inherits Contributor, plus full ownership of user and review moderation — including banning a user and deleting/clearing a review's text (not just triaging reports), and AI summary regeneration. Only catalog deletion and role management stay Admin-exclusive.
  - **Admin**: inherits Moderator, plus deletion everywhere and role management. `ROLE_SUPER_ADMIN` is removed and folded in.
- Fixes a CSRF gap: 5 GET-triggerable moderation/regeneration actions are now POST + validated token (mirroring EasyAdmin's own DELETE pattern).
- Adds a missing DELETE permission check on `Coaster` and `Image` (previously open to any `/team` user).
- Replaces the free-text `roles` field on the User admin with a fixed choice list.
- Groups the admin menu into Content / Moderation / Administration sections.
- Data migration remaps existing accounts: `ROLE_ADMIN` → `ROLE_MODERATOR`, `ROLE_SUPER_ADMIN` → `ROLE_ADMIN`.

## Test plan
- [x] `php-cs-fixer`, `phpstan`, `phpunit` all green
- [x] Migration tested up/down against a cloned worktree database
- [x] Verified live via Playwright against all 3 tiers: menu visibility, direct-URL 403 enforcement, and a CSRF-protected action round-trip (real POST + valid token)
- [x] Security review pass completed, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YNtXKeaFkQA7DfL8wHK6A
