### PR TITLE
chore(notifications): restart messenger worker on deploy, add scoped test command

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -179,6 +179,19 @@ reload_php_fpm() {
     fi
 }
 
+# Function to restart the messenger worker (systemd service consuming the
+# async transport). A long-running CLI worker doesn't benefit from PHP-FPM's
+# OPcache reload above — without this, it keeps running whatever code was
+# loaded when it last started, indefinitely.
+restart_messenger_worker() {
+    log "Restarting messenger worker..."
+    if sudo systemctl restart captain-messenger.service 2>/dev/null; then
+        success "Messenger worker restarted"
+    else
+        warning "Could not restart messenger worker automatically. Run manually: sudo systemctl restart captain-messenger.service"
+    fi
+}
+
 # Function to verify deployment
 verify_deployment() {
     log "Verifying deployment..."
@@ -227,6 +240,7 @@ finalize_deploy() {
     clear_cache
     warm_cache
     reload_php_fpm
+    restart_messenger_worker
     verify_deployment
     disable_maintenance
 }
@@ -385,6 +399,7 @@ show_usage() {
     echo "  assets       Build production assets with Webpack Encore"
     echo "  migrate      Run database migrations"
     echo "  cache        Clear and warm cache"
+    echo "  messenger-restart  Restart the messenger worker (systemd)"
     echo "  verify       Verify deployment"
     echo "  rollback     Rollback code and optionally migrations"
     echo "  help         Show this help message"
@@ -401,6 +416,7 @@ show_usage() {
     echo "  $0 assets"
     echo "  $0 migrate"
     echo "  $0 cache"
+    echo "  $0 messenger-restart"
     echo "  $0 verify"
     echo "  $0 maintenance off"
 }
@@ -443,6 +459,9 @@ case "${1:-help}" in
         clear_cache
         warm_cache
         reload_php_fpm
+        ;;
+    "messenger-restart")
+        restart_messenger_worker
         ;;
     "verify")
         verify_deployment

--- a/src/Command/NotificationTestSendCommand.php
+++ b/src/Command/NotificationTestSendCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Enum\NotificationType;
+use App\Repository\UserRepository;
+use App\Service\NotificationService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Sends a real notification to exactly one user via {@see NotificationService::send()}
+ * — never the broadcast path — so the full pipeline (rendering, content
+ * dedup, email gating, async dispatch) can be verified against a single
+ * account without touching anyone else. Useful in particular for Ranking,
+ * which otherwise only fires for real on the 1st of the month via
+ * ranking:update and always broadcasts to every user.
+ */
+#[AsCommand(
+    name: 'app:notification:test-send',
+    description: 'Send a test notification to one user only — never broadcasts',
+    hidden: true,
+)]
+class NotificationTestSendCommand extends Command
+{
+    public function __construct(
+        private readonly NotificationService $notificationService,
+        private readonly UserRepository $userRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('userId', InputArgument::REQUIRED, 'User ID to send the test notification to')
+            ->addOption('type', null, InputOption::VALUE_REQUIRED, 'ranking|badge|announcement', 'ranking')
+            ->addOption('coaster', null, InputOption::VALUE_REQUIRED, 'Highlighted coaster name (ranking type only)');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        /** @var int $userId */
+        $userId = $input->getArgument('userId');
+        $user = $this->userRepository->find($userId);
+        if (null === $user) {
+            $io->error(\sprintf('User #%d not found.', $userId));
+
+            return Command::FAILURE;
+        }
+
+        /** @var string $typeOption */
+        $typeOption = $input->getOption('type');
+        $type = NotificationType::tryFrom($typeOption);
+        if (null === $type) {
+            $io->error('--type must be one of: ranking, badge, announcement');
+
+            return Command::FAILURE;
+        }
+
+        /** @var ?string $coaster */
+        $coaster = $input->getOption('coaster');
+        [$message, $parameter] = match ($type) {
+            NotificationType::Ranking => [null !== $coaster ? 'notif.ranking.messageWithNewCoaster' : 'notif.ranking.message', $coaster],
+            NotificationType::Badge => ['notif.badge.message', 'badge.rating1'],
+            NotificationType::Announcement => ['notif.announcement.emailDefaultChanged', null],
+        };
+
+        $this->notificationService->send($user, $type, $message, $parameter);
+
+        $io->success(\sprintf('Test %s notification sent to user #%d (%s) only.', $type->value, $user->getId(), $user->getEmail()));
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
## Summary
- `deploy.sh` now restarts the messenger worker (systemd) as part of `finalize_deploy()` — it's a new piece of infra from the notification refactor and, unlike PHP-FPM, doesn't pick up new code on its own. Also exposed standalone as `./deploy.sh messenger-restart`.
- Adds a hidden `app:notification:test-send <userId> --type=ranking|badge|announcement [--coaster=...]` command that sends a real notification to exactly one user via `NotificationService::send()` — never the broadcast path. Needed because Ranking notifications otherwise only fire for real on the 1st of the month via `ranking:update`, which always broadcasts to every user with no way to scope a manual test down to one account.

## Requires (server-side, not tracked here)
A `captain-messenger.service` systemd unit consuming `messenger:consume async` must exist on the server before this lands, otherwise `messenger-restart` just warns and no-ops:

```ini
[Unit]
Description=Captain Coaster - Messenger worker (async notifications)
After=network.target redis.service

[Service]
Type=simple
User=<deploy-user>
WorkingDirectory=<project-path>
ExecStart=/usr/bin/php bin/console messenger:consume async --time-limit=3600 --memory-limit=128M --env=prod --no-debug
Restart=always
RestartSec=5

[Install]
WantedBy=multi-user.target
```

## Test plan
- [x] Verified `app:notification:test-send 1 --type=ranking --coaster="Steel Vengeance"` in dev: exactly 1 `notification_recipient` row created, 0 messages queued (recipient has email off), notification renders correctly on `/notifications`.
- [x] Confirmed the command is hidden from `bin/console list` but still runnable by name.
- [x] `bash -n deploy.sh` — syntax OK.
- [x] Full PHPUnit suite (264 tests) + PHPStan pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017s4LrA3aGTnQJ9nZ29gjMJ