### PR TITLE
perf(search): cut N+1 queries, cache results, fix filesort indexes

### DIFF
--- a/migrations/Version20260906113350.php
+++ b/migrations/Version20260906113350.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260906113350 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add index on coaster.updated_at so updatedAt-sorted listings (e.g. the admin coaster/park/image CRUD lists, default-sorted this way) are not a filesort over the whole table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_coaster_updated_at ON coaster (updated_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_coaster_updated_at ON coaster');
+    }
+}

--- a/migrations/Version20260906115217.php
+++ b/migrations/Version20260906115217.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260906115217 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add index on coaster.openingDate, the new default sort for the search-coaster listing, so it is not a filesort over the whole table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_coaster_opening_date ON coaster (openingDate)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_coaster_opening_date ON coaster');
+    }
+}

--- a/migrations/Version20260906115507.php
+++ b/migrations/Version20260906115507.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260906115507 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add index on coaster.rank so the default (unfiltered) ranking listing, sorted by rank, is not a filesort over the whole table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_coaster_rank ON coaster (rank)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_coaster_rank ON coaster');
+    }
+}

--- a/src/Controller/CoasterSearchController.php
+++ b/src/Controller/CoasterSearchController.php
@@ -55,7 +55,12 @@ class CoasterSearchController extends AbstractController
             $pagination = $this->paginator->paginate(
                 $this->coasterRepository->findForSearch($validatedFilters),
                 $page,
-                20
+                20,
+                // Every join in findForSearch() is ManyToOne/OneToOne, so it can
+                // never duplicate a coaster row -- skip KnpPaginator's extra
+                // "distinct id" pre-query, which exists only to guard against
+                // *-to-many joins.
+                [PaginatorInterface::DISTINCT => false]
             );
         } catch (AccessDeniedHttpException $e) {
             throw $e;

--- a/src/Entity/Coaster.php
+++ b/src/Entity/Coaster.php
@@ -27,6 +27,9 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Table(name: 'coaster')]
 #[ORM\Index(name: 'idx_coaster_name_search', columns: ['name'])]
 #[ORM\Index(name: 'idx_coaster_slug_search', columns: ['slug'])]
+#[ORM\Index(name: 'idx_coaster_updated_at', columns: ['updated_at'])]
+#[ORM\Index(name: 'idx_coaster_opening_date', columns: ['openingDate'])]
+#[ORM\Index(name: 'idx_coaster_rank', columns: ['rank'])]
 #[ApiResource(
     operations: [
         new Get(normalizationContext: ['groups' => ['read_coaster']]),

--- a/src/Entity/RiddenCoaster.php
+++ b/src/Entity/RiddenCoaster.php
@@ -48,8 +48,14 @@ class RiddenCoaster
     #[ORM\Column(type: Types::STRING, length: 5)]
     private string $language = 'en';
 
-    /** DB-generated (mirrors `review IS NOT NULL`) for idx_ridden_coaster_has_review_updated_at -- never run schema:update --force, it'll try to drop the generated expression. */
-    #[ORM\Column(type: Types::BOOLEAN, insertable: false, updatable: false)]
+    /**
+     * DB-generated (mirrors `review IS NOT NULL`) for idx_ridden_coaster_has_review_updated_at.
+     * nullable: true because MariaDB doesn't support NOT NULL on generated
+     * columns at all, even though this one's expression can never produce
+     * NULL. Never run schema:update --force, it'll try to drop the
+     * generated expression.
+     */
+    #[ORM\Column(type: Types::BOOLEAN, nullable: true, insertable: false, updatable: false)]
     private bool $hasReview = false;
 
     /** @var Collection<int, Tag> */

--- a/src/Repository/CoasterRepository.php
+++ b/src/Repository/CoasterRepository.php
@@ -149,17 +149,61 @@ class CoasterRepository extends ServiceEntityRepository
      */
     public function findForSearch(array $filters = []): Query
     {
-        $qb = $this->createBaseQuery()->select('c');
+        $qb = $this->createBaseQuery()
+            ->select('c', 'p', 'country', 'm', 'mt')
+            ->leftJoin('c.mainImage', 'mi')
+            ->addSelect('mi');
         $this->applyFilters($qb, $filters, 'search');
 
-        // Sort by distance if coordinates provided, otherwise by updatedAt
-        if ($this->hasValidCoordinates($filters)) {
-            $this->applyDistanceSort($qb, $filters['latitude'], $filters['longitude']);
-        } else {
-            $qb->orderBy('c.updatedAt', 'DESC');
+        $isDistanceSort = $this->hasValidCoordinates($filters);
+        if ($isDistanceSort) {
+            // Only the "park has coordinates" filter -- not the visitor's
+            // own lat/lng -- affects which rows match, so it has to be in
+            // before the count clone below. The HIDDEN distance SELECT and
+            // ORDER BY (added later, via applyDistanceSort()) only matter
+            // for the main query.
+            $qb->andWhere('p.latitude IS NOT NULL')->andWhere('p.longitude IS NOT NULL');
         }
 
-        return $qb->getQuery();
+        // Same gate as findForRanking(): filters['user'] alone is a no-op
+        // query-wise (see applyUserFilters) -- only an actual ridden/notridden
+        // toggle changes the query -- but the frontend sends it on every
+        // request for a logged-in visitor, so gating on its mere presence
+        // would disable caching for all of them.
+        $hasUserSpecificFilter = 'on' === ($filters['ridden'] ?? null) || 'on' === ($filters['notridden'] ?? null);
+
+        // Every join here is ManyToOne/OneToOne, so a plain count can never
+        // over/under-count -- compute and cache it ourselves and hand it to
+        // KnpPaginator via a hint, instead of letting it run its own
+        // (uncached) COUNT(*) query on every request.
+        $countQuery = (clone $qb)->select('count(c.id)')->getQuery();
+        if (!$hasUserSpecificFilter) {
+            $countQuery->enableResultCache(300);
+        }
+        $count = (int) $countQuery->getSingleScalarResult();
+
+        if ($isDistanceSort) {
+            $this->applyDistanceSort($qb, $filters['latitude'], $filters['longitude']);
+        } else {
+            // Newest coasters first; unknown opening dates sort last (NULLs
+            // sort lowest in DESC order). Ties (shared opening dates) broken
+            // by id for stable pagination.
+            $qb->orderBy('c.openingDate', 'DESC')->addOrderBy('c.id', 'DESC');
+        }
+
+        $query = $qb->getQuery();
+        $query->setHint('knp_paginator.count', $count);
+
+        // Distance sort binds the visitor's real-valued coordinates as query
+        // parameters -- Doctrine's result cache key includes them, so caching
+        // the main query here would never hit and would only fill the cache
+        // with entries reused by no one else. The count above is unaffected,
+        // since it depends on whether coordinates are set, not their value.
+        if (!$hasUserSpecificFilter && !$isDistanceSort) {
+            $query->enableResultCache(300); // Cache for 5 minutes - public data only
+        }
+
+        return $query;
     }
 
     /**
@@ -474,7 +518,9 @@ class CoasterRepository extends ServiceEntityRepository
     private function applyDistanceSort(QueryBuilder $qb, float $latitude, float $longitude): void
     {
         // Haversine formula for distance calculation (in km)
-        // Using a simplified version that works well for sorting purposes
+        // Using a simplified version that works well for sorting purposes.
+        // The "park has coordinates" WHERE is applied by the caller, before
+        // this -- it affects the row count, unlike this SELECT/ORDER BY.
         $qb->addSelect(
             '(6371 * ACOS(
                 COS(RADIANS(:userLat)) * COS(RADIANS(p.latitude)) *
@@ -482,8 +528,6 @@ class CoasterRepository extends ServiceEntityRepository
                 SIN(RADIANS(:userLat)) * SIN(RADIANS(p.latitude))
             )) AS HIDDEN distance'
         )
-            ->andWhere('p.latitude IS NOT NULL')
-            ->andWhere('p.longitude IS NOT NULL')
             ->setParameter('userLat', $latitude)
             ->setParameter('userLng', $longitude)
             ->orderBy('distance', 'ASC');

--- a/tests/Repository/CoasterRepositoryTest.php
+++ b/tests/Repository/CoasterRepositoryTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Unit tests for CoasterRepository::findForRanking().
+ * Unit tests for CoasterRepository::findForRanking() and findForSearch().
  *
  * Uses a real ManagerRegistry/ClassMetadata pair (rather than the simpler
  * onlyMethods(['getEntityManager']) partial mock used elsewhere) because
@@ -33,7 +33,7 @@ class CoasterRepositoryTest extends TestCase
     /** @var list<string> */
     private array $capturedDql = [];
 
-    /** @var list<array{lifetime: ?int}> */
+    /** @var list<array{lifetime: ?int, isCount: bool}> */
     private array $capturedResultCacheCalls = [];
 
     /** @var array<string, mixed> */
@@ -78,8 +78,8 @@ class CoasterRepositoryTest extends TestCase
 
                 return $query;
             });
-            $query->method('enableResultCache')->willReturnCallback(function (?int $lifetime) use ($query) {
-                $this->capturedResultCacheCalls[] = ['lifetime' => $lifetime];
+            $query->method('enableResultCache')->willReturnCallback(function (?int $lifetime) use ($query, $dql) {
+                $this->capturedResultCacheCalls[] = ['lifetime' => $lifetime, 'isCount' => str_contains($dql, 'count(c.id)')];
 
                 return $query;
             });
@@ -128,6 +128,29 @@ class CoasterRepositoryTest extends TestCase
         $this->assertContains('mi', $selectedAliases);
     }
 
+    public function testFindForSearchFetchJoinsParkCountryManufacturerMaterialTypeAndMainImage(): void
+    {
+        $this->stubQueries(0);
+
+        $this->repository->findForSearch();
+
+        $dql = $this->mainEntityDql();
+
+        // Regression guard: these were previously joined (for filtering) but
+        // not selected, so Twig's coaster.park / .park.country / .manufacturer
+        // / .materialType / .mainImage access in results.html.twig lazy-loaded
+        // them one row at a time -- up to 20 rows per search page.
+        $matched = preg_match('/^SELECT (.*?) FROM /', $dql, $matches);
+        $this->assertSame(1, $matched, "Could not find a SELECT clause in DQL: $dql");
+        $selectedAliases = array_map('trim', explode(',', $matches[1]));
+
+        $this->assertContains('p', $selectedAliases);
+        $this->assertContains('country', $selectedAliases);
+        $this->assertContains('m', $selectedAliases);
+        $this->assertContains('mt', $selectedAliases);
+        $this->assertContains('mi', $selectedAliases);
+    }
+
     public function testSetsKnpPaginatorCountHintFromASeparateCountQuery(): void
     {
         $this->stubQueries(42);
@@ -168,5 +191,50 @@ class CoasterRepositoryTest extends TestCase
         $this->repository->findForRanking(['user' => 42, 'notridden' => 'on']);
 
         $this->assertSame([], $this->capturedResultCacheCalls);
+    }
+
+    public function testFindForSearchSetsKnpPaginatorCountHintFromASeparateCountQuery(): void
+    {
+        $this->stubQueries(17);
+
+        $this->repository->findForSearch();
+
+        $this->assertSame(17, $this->capturedHints['knp_paginator.count']);
+    }
+
+    public function testFindForSearchCachesBothQueriesWithNoFilters(): void
+    {
+        $this->stubQueries(0);
+
+        // The default, filterless search (most visits) must be cacheable,
+        // same as findForRanking()'s default view.
+        $this->repository->findForSearch();
+
+        $this->assertCount(2, $this->capturedResultCacheCalls);
+        foreach ($this->capturedResultCacheCalls as $call) {
+            $this->assertSame(300, $call['lifetime']);
+        }
+    }
+
+    public function testFindForSearchDoesNotCacheWhenTheRiddenFilterIsActive(): void
+    {
+        $this->stubQueries(0);
+
+        $this->repository->findForSearch(['user' => 42, 'ridden' => 'on']);
+
+        $this->assertSame([], $this->capturedResultCacheCalls);
+    }
+
+    public function testFindForSearchCachesTheCountButNotTheMainQueryWhenSortingByDistance(): void
+    {
+        $this->stubQueries(0);
+
+        // The "park has coordinates" WHERE (shared by every visitor sorting
+        // by distance) makes the count cacheable, but the main query embeds
+        // the visitor's own lat/lng as bound parameters, so caching it would
+        // never hit.
+        $this->repository->findForSearch(['sortByDistance' => 'on', 'latitude' => 48.85, 'longitude' => 2.35]);
+
+        $this->assertSame([['lifetime' => 300, 'isCount' => true]], $this->capturedResultCacheCalls);
     }
 }


### PR DESCRIPTION
## Summary
- `findForSearch()` only selected `c`, so every access to park/country/manufacturer/materialType/mainImage in `results.html.twig` lazy-loaded one row at a time (33 → 3 queries on the default listing). Fetch-join them, and skip KnpPaginator's distinct-id pre-query (every join is ManyToOne/OneToOne).
- Add the same caching `findForRanking()` already has: cacheable unless a ridden/notridden filter is active, or distance-sort is used (binds the visitor's own coordinates, so caching it would never hit — the count query is unaffected).
- Switch the default sort from `updatedAt` (an edit-time signal) to `openingDate DESC` — newest coasters first, unknown dates last.
- Add indexes backing sorts that were causing filesorts over the whole `coaster` table: `openingDate` (new search default), `rank` (ranking page's default sort — same issue, missed by #368), and `updated_at` (still used by the admin CRUD listings).
- Fix `RiddenCoaster::hasReview` mapping: it declared `nullable: false`, but MariaDB doesn't support `NOT NULL` on generated columns at all — `doctrine:migrations:diff` kept proposing a broken `CHANGE` that would've dropped the `GENERATED ALWAYS AS (...)` expression. No behavior change, the value is never actually NULL.

## Test plan
- [x] `vendor/bin/phpunit` (280 tests, including new coverage for `findForSearch()`'s fetch-joins and caching gates)
- [x] `vendor/bin/phpstan analyse` clean
- [x] `vendor/bin/php-cs-fixer fix` clean
- [x] Verified live via the Symfony profiler: default search listing 33 → 3 queries (cold cache), 3 → 1 on repeat; distance-sort correctly leaves the main query uncached
- [x] `EXPLAIN` before/after on the new indexes: `Using filesort` → indexed scan, for both the search default sort and the ranking page's `rank` sort