### PR TITLE
fix(coaster,park): require numeric id on show_coaster/park_show routes

### DIFF
--- a/src/Controller/CoasterController.php
+++ b/src/Controller/CoasterController.php
@@ -192,7 +192,7 @@ class CoasterController extends BaseController
     }
 
     /** Show details of a coaster */
-    #[Route(path: '/{id}/{slug}', name: 'show_coaster', options: ['expose' => true], methods: ['GET'])]
+    #[Route(path: '/{id}/{slug}', name: 'show_coaster', requirements: ['id' => '\d+'], options: ['expose' => true], methods: ['GET'])]
     public function showAction(
         Request $request,
         #[MapEntity(expr: 'repository.findForShow(id)')]

--- a/src/Controller/ParkController.php
+++ b/src/Controller/ParkController.php
@@ -24,7 +24,7 @@ class ParkController extends AbstractController
     }
 
     /** Show park details. */
-    #[Route(path: '/{id}/{slug}', name: 'park_show', options: ['expose' => true], methods: ['GET'])]
+    #[Route(path: '/{id}/{slug}', name: 'park_show', requirements: ['id' => '\d+'], options: ['expose' => true], methods: ['GET'])]
     public function showAction(
         ParkRepository $parkRepository,
         Park $park,


### PR DESCRIPTION
## Summary
Production incident: `/coasters/{slug}/reviews?page=N` (a distributed scraper hitting the AJAX-only reviews-tab URL directly, without the `X-Requested-With` header `coaster_reviews_ajax_load` requires) was falling through to `show_coaster`'s `/{id}/{slug}` route, binding the slug to `{id}`. `CoasterRepository::findForShow(int $id)` then threw an uncaught `TypeError` (string given) -- a live 500 on prod since PR #370 introduced that strictly-typed method.

- `show_coaster`: added `requirements: ['id' => '\d+']`, the same convention already used on every other numeric route segment in this codebase. Confirmed via `router:match` that the malformed URL now matches no route (clean 404) and a real numeric coaster URL still matches `show_coaster`.
- `park_show`: same `/{id}/{slug}` shape. Not currently crashing (its `Park $park` argument resolves via the default `EntityValueResolver`, which 404s gracefully instead of calling a strictly-typed repository method), but closing the same hole proactively since it's the identical pattern.

## Test plan
- [x] `vendor/bin/phpunit` (293 tests, green)
- [x] `vendor/bin/phpstan analyse` (no errors)
- [x] `vendor/bin/php-cs-fixer fix --dry-run` (clean)
- [x] `bin/console router:match` confirms the malformed URL now matches nothing, and a legitimate numeric coaster URL still matches `show_coaster`
- [x] Reproduced live on prod before the fix: `curl .../coasters/{slug}/reviews` → 500 without an XHR header, 200 with one (confirming the AJAX route works fine and only the fallback match is broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nTKmQWnfPpDEiW1rs9yYg