### PR TITLE
fix(ridden-coaster): add missing updated_at index, fix homepage disk-full errors

### DIFF
--- a/migrations/Version20260906184455.php
+++ b/migrations/Version20260906184455.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260906184455 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return "Add plain index on ridden_coaster.updated_at -- DefaultController's homepage query (getLatestRatings()) sorts by updated_at with no other filter on this table, so the existing has_review-led composite indexes can't help; MariaDB was falling back to a full table scan + filesort (826k rows), spilling to an on-disk temp table on every cache miss. Confirmed as the cause of the 'disk full'/'table file is corrupted' errors seen right after each of today's deploys, when cache:clear wipes the Redis result-cache pool and several homepage requests race to recompute this at once.";
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_ridden_coaster_updated_at ON ridden_coaster (updated_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_ridden_coaster_updated_at ON ridden_coaster');
+    }
+}

--- a/src/Entity/RiddenCoaster.php
+++ b/src/Entity/RiddenCoaster.php
@@ -16,6 +16,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\UniqueConstraint(name: 'user_coaster_unique', columns: ['coaster_id', 'user_id'])]
 #[ORM\Index(name: 'idx_ridden_coaster_moderated_at', columns: ['moderated_at'])]
+#[ORM\Index(name: 'idx_ridden_coaster_updated_at', columns: ['updated_at'])]
 #[ORM\Index(name: 'idx_ridden_coaster_has_review_updated_at', columns: ['has_review', 'updated_at'])]
 #[ORM\Index(name: 'idx_ridden_coaster_has_review_language_updated_at', columns: ['has_review', 'language', 'updated_at'])]
 #[ORM\Index(name: 'idx_ridden_coaster_created_at', columns: ['created_at'])]


### PR DESCRIPTION
## Summary
Recurring production incident (hit on both of today's deploys, ~19:55 and ~20:33): `DriverException: Disk got full writing '.(temporary)'` and `Table file is corrupted for '/tmp/#sql-temptable-...'`, both traced to `DefaultController::index()` → `RiddenCoasterRepository::getLatestRatings()`.

**Root cause**: that query sorts `ridden_coaster` by `updated_at` with no other filter on the table. Every existing index on this column leads with `has_review`, so none can serve this `ORDER BY` — MariaDB fell back to a full table scan + filesort of all 826k rows, spilling to an on-disk temp table (the in-memory sort buffer is capped at `tmp_table_size` = 16MB, far below what sorting 826k rows needs).

**Why now, not before**: the homepage's `enableResultCache(300)` normally hides this behind a 5-minute cache. But `deploy.sh`'s `clear_cache()` step (`cache:clear`) wipes the Redis-backed `doctrine.result_cache_pool` on *every* deploy — `cache:warmup` doesn't re-populate ad-hoc `enableResultCache()` entries — and the PHP-FPM reload right after briefly queues requests that then fire in a burst. Several homepage requests raced to recompute the same expensive full-table sort simultaneously, right when `/tmp` (a small tmpfs) had the least room to spare.

**Fix**: plain index on `ridden_coaster.updated_at`. Confirmed via `EXPLAIN`: rows scanned drops from 826076 to 6, filesort gone.

## Test plan
- [x] `vendor/bin/phpunit` (293 tests, green)
- [x] `vendor/bin/phpstan analyse` (no errors)
- [x] `vendor/bin/php-cs-fixer fix --dry-run` (clean)
- [x] `EXPLAIN` on the exact homepage query before/after: `type: ALL, rows: 826076, Using filesort` → `type: index, rows: 6`, no filesort
- [x] Migration applies cleanly against a full production data clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nTKmQWnfPpDEiW1rs9yYg