### PR TITLE
fix(ridden-coaster,image): stop 3 homepage queries from scanning the whole table

### DIFF
--- a/src/Repository/ImageRepository.php
+++ b/src/Repository/ImageRepository.php
@@ -9,6 +9,7 @@ use App\Entity\Image;
 use App\Entity\LikedImage;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -22,23 +23,56 @@ class ImageRepository extends ServiceEntityRepository
         parent::__construct($registry, Image::class);
     }
 
+    /** @throws NoResultException */
     public function findLatestLikedImage(): Image
     {
+        // Two-step, same reasoning as RiddenCoasterRepository::getLatestRatings():
+        // ORDER BY + LIMIT on the joined `li` table combined with a WHERE on
+        // the driving `image` table is the same MariaDB optimizer pathology
+        // in mirror image -- get the most-recently-liked candidate ids off
+        // liked_image alone first (cheap, no join), then filter/hydrate that
+        // small set. Ranking is redone in PHP instead of an SQL `ORDER BY
+        // FIELD(...)` -- DQL has no equivalent function registered here.
+        $candidateIds = $this->getEntityManager()
+            ->createQueryBuilder()
+            ->select('IDENTITY(li.image)')
+            ->from(LikedImage::class, 'li')
+            ->orderBy('li.id', 'DESC')
+            ->setMaxResults(10)
+            ->getQuery()
+            ->enableResultCache(600)
+            ->getSingleColumnResult();
+
+        if ([] === $candidateIds) {
+            throw new NoResultException();
+        }
+
         $query = $this->createQueryBuilder('i')
             ->addSelect('c', 'st', 'mi')
-            ->join(LikedImage::class, 'li', 'WITH', 'li.image = i.id')
             ->innerJoin('i.coaster', 'c')
             ->leftJoin('c.seatingType', 'st')
             ->leftJoin('c.mainImage', 'mi')
-            ->where('i.enabled = 1')
+            ->where('i.id IN (:ids)')
+            ->andWhere('i.enabled = 1')
             ->andWhere('i.credit IS NOT NULL')
-            ->orderBy('li.id', 'DESC')
-            ->setMaxResults(1)
+            ->setParameter('ids', $candidateIds)
             ->getQuery();
 
         $query->enableResultCache(600);
 
-        return $query->getSingleResult();
+        /** @var array<int, Image> $matchesById */
+        $matchesById = [];
+        foreach ($query->getResult() as $match) {
+            $matchesById[$match->getId()] = $match;
+        }
+
+        foreach ($candidateIds as $id) {
+            if (isset($matchesById[$id])) {
+                return $matchesById[$id];
+            }
+        }
+
+        throw new NoResultException();
     }
 
     /**

--- a/src/Repository/RiddenCoasterRepository.php
+++ b/src/Repository/RiddenCoasterRepository.php
@@ -223,6 +223,30 @@ class RiddenCoasterRepository extends ServiceEntityRepository
      */
     public function getLatestReviews(array $preferredReviewLanguages = ['en'], int $limit = 3): array
     {
+        // Two-step, same reasoning as getLatestRatings() below: a WHERE on
+        // the joined `users` table alongside ORDER BY + LIMIT on
+        // ridden_coaster is a known MariaDB optimizer pathology (can degrade
+        // to scanning most of the table instead of stopping at LIMIT) --
+        // the plain updated_at index added in #374 didn't fully fix it, only
+        // made it less likely. Get candidate ids off the plain
+        // has_review/updated_at index first -- cheap and bounded regardless
+        // of plan -- then rank/hydrate that small set with the
+        // language-priority CASE and the joins.
+        $candidateIds = $this->getEntityManager()
+            ->createQueryBuilder()
+            ->select('r.id')
+            ->from(RiddenCoaster::class, 'r')
+            ->where('r.hasReview = 1')
+            ->orderBy('r.updatedAt', 'desc')
+            ->setMaxResults($limit * 10)
+            ->getQuery()
+            ->enableResultCache(300)
+            ->getSingleColumnResult();
+
+        if ([] === $candidateIds) {
+            return [];
+        }
+
         $query = $this->getEntityManager()
             ->createQueryBuilder()
             ->select('r')
@@ -236,12 +260,13 @@ class RiddenCoasterRepository extends ServiceEntityRepository
             ->innerJoin('c.park', 'p')
             ->leftJoin('c.seatingType', 'st')
             ->leftJoin('c.mainImage', 'mi')
-            ->where('r.hasReview = 1')
+            ->where('r.id IN (:ids)')
             ->andWhere('u.enabled = 1')
             ->orderBy('languagePriority', 'asc')
             ->addOrderBy('r.updatedAt', 'desc')
-            ->setMaxResults($limit)
+            ->setParameter('ids', $candidateIds)
             ->setParameter('preferredReviewLanguages', $preferredReviewLanguages)
+            ->setMaxResults($limit)
             ->getQuery();
 
         $query->enableResultCache(300);
@@ -256,6 +281,29 @@ class RiddenCoasterRepository extends ServiceEntityRepository
      */
     public function getLatestRatings(int $limit = 6): array
     {
+        // Two steps on purpose: ORDER BY r.updatedAt + LIMIT together with a
+        // WHERE on the joined `users` table makes MariaDB abandon the cheap
+        // "index order, stop at LIMIT" plan and scan most of ridden_coaster
+        // instead (seen examining 2M+ rows / 13s in production even with the
+        // plain updated_at index from #374 in place -- that index alone
+        // doesn't force the optimizer to use it correctly here). Getting
+        // candidate ids off the bare, unfiltered index first keeps that scan
+        // to exactly $limit * 5 rows; the second query only ever touches that
+        // small id set, so filtering/joining there is free regardless of plan.
+        $candidateIds = $this->getEntityManager()
+            ->createQueryBuilder()
+            ->select('r.id')
+            ->from(RiddenCoaster::class, 'r')
+            ->orderBy('r.updatedAt', 'desc')
+            ->setMaxResults($limit * 5)
+            ->getQuery()
+            ->enableResultCache(300)
+            ->getSingleColumnResult();
+
+        if ([] === $candidateIds) {
+            return [];
+        }
+
         $query = $this->getEntityManager()
             ->createQueryBuilder()
             ->select('r', 'u', 'c', 'st', 'mi')
@@ -264,8 +312,10 @@ class RiddenCoasterRepository extends ServiceEntityRepository
             ->innerJoin('r.coaster', 'c')
             ->leftJoin('c.seatingType', 'st')
             ->leftJoin('c.mainImage', 'mi')
-            ->where('u.enabled = 1')
+            ->where('r.id IN (:ids)')
+            ->andWhere('u.enabled = 1')
             ->orderBy('r.updatedAt', 'desc')
+            ->setParameter('ids', $candidateIds)
             ->setMaxResults($limit)
             ->getQuery();
 


### PR DESCRIPTION
## Summary
- `getLatestRatings()`, `getLatestReviews()`, and `findLatestLikedImage()` each combine `ORDER BY` + `LIMIT` on their driving table with a `WHERE` filter on a joined table -- a known MariaDB optimizer pathology that can degrade to scanning most of the table instead of stopping at `LIMIT`.
- Confirmed in production: `getLatestRatings()` examining 2.4M+ rows and taking up to 13s, causing the "disk got full writing '.(temporary)'" / corrupted-temp-table incidents on 2026-09-06/07. The plain `updated_at` index added in #374 reduced the odds but didn't eliminate the pathology -- incidents continued after that merge.
- Fix: split each into two queries -- candidate ids off the bare, unfiltered index first (cheap, bounded, no join), then filter/hydrate only that small id set with the joins. Correctness of the query plan no longer matters once the candidate set is capped.
- `findLatestLikedImage()` ranks its final pick in PHP rather than `ORDER BY FIELD(...)` in SQL, since DQL has no such function registered in this project.

Not touched (different problem shape, larger scope): `getCoasterReviews()` / `findAllReviews()` have genuine `*-to-many` joins (pros/cons/upvotes) that need `DISTINCT`, which is a separate concern.

## Test plan
- [x] `vendor/bin/phpstan analyse` clean
- [x] `vendor/bin/php-cs-fixer fix` clean
- [x] `vendor/bin/phpunit` -- 293 tests pass
- [x] All three new query shapes timed directly against production data (read-only): ~40-70ms total per method, down from up to 13s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018whEUbUHtjDSRB1Jz1b3vs