### PR TITLE
feat(css): migrate .alert, .close, .pagination to Tailwind v4 (Phase 2)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -22,6 +22,10 @@ import 'bootstrap/js/transition'; // Required dependency for other components
 // Import main stylesheet (includes Bootstrap 3.3.7 and custom theme)
 import '../styles/app.less';
 
+// Tailwind v4 — components migrated off Bootstrap/LESS land here.
+// See docs/adr/0001-ui-modernization-phasing.md (Phase 2).
+import '../styles/tailwind.css';
+
 // Import theme JavaScript files (migrated from public/js/core/) - Critical for layout
 import './theme/theme';
 import './theme/layout_fixed_custom';

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -23,7 +23,7 @@ import 'bootstrap/js/transition'; // Required dependency for other components
 import '../styles/app.less';
 
 // Tailwind v4 — components migrated off Bootstrap/LESS land here.
-// See docs/adr/0001-ui-modernization-phasing.md (Phase 2).
+// See the Phase 2 tracking issue: captain-coaster/captain-coaster#380.
 import '../styles/tailwind.css';
 
 // Import theme JavaScript files (migrated from public/js/core/) - Critical for layout

--- a/assets/styles/app.less
+++ b/assets/styles/app.less
@@ -51,7 +51,6 @@
 @import 'bootstrap/less/labels.less';
 @import 'bootstrap/less/badges.less';
 @import 'bootstrap/less/thumbnails.less';
-@import 'bootstrap/less/alerts.less';
 @import 'bootstrap/less/media.less';
 @import 'bootstrap/less/list-group.less';
 @import 'bootstrap/less/panels.less';
@@ -65,7 +64,6 @@
 @import 'theme/bootstrap-limitless/dropdowns.less'; // 47% usage
 @import 'theme/bootstrap-limitless/navbar.less'; // 28% usage (but core component)
 @import 'theme/bootstrap-limitless/navs.less'; // 30% usage
-@import 'theme/bootstrap-limitless/alerts.less'; // 40% usage
 @import 'theme/bootstrap-limitless/badges.less'; // 47% usage
 @import 'theme/bootstrap-limitless/labels.less'; // 44% usage
 @import 'theme/bootstrap-limitless/media.less'; // 70% usage

--- a/assets/styles/app.less
+++ b/assets/styles/app.less
@@ -46,15 +46,12 @@
 @import 'bootstrap/less/navs.less';
 @import 'bootstrap/less/navbar.less';
 @import 'bootstrap/less/breadcrumbs.less';
-@import 'bootstrap/less/pagination.less';
-@import 'bootstrap/less/pager.less';
 @import 'bootstrap/less/labels.less';
 @import 'bootstrap/less/badges.less';
 @import 'bootstrap/less/thumbnails.less';
 @import 'bootstrap/less/media.less';
 @import 'bootstrap/less/list-group.less';
 @import 'bootstrap/less/panels.less';
-@import 'bootstrap/less/close.less';
 @import 'bootstrap/less/modals.less';
 
 // Import theme overrides for high-usage Bootstrap components
@@ -74,11 +71,8 @@
 @import 'theme/bootstrap-limitless/forms.less'; // 29% usage
 @import 'theme/bootstrap-limitless/tables.less'; // 29% usage
 @import 'theme/bootstrap-limitless/list-group.less'; // 38% usage
-@import 'theme/bootstrap-limitless/pagination.less'; // 25% usage
-@import 'theme/bootstrap-limitless/pager.less'; // 22% usage
 @import 'theme/bootstrap-limitless/button-groups.less'; // 26% usage
 @import 'theme/bootstrap-limitless/input-groups.less'; // 20% usage
-@import 'theme/bootstrap-limitless/close.less'; // 50% usage
 
 // Import theme's core layout components (high usage)
 @import 'theme/core/layout/content.less'; // 100% usage

--- a/assets/styles/tailwind.css
+++ b/assets/styles/tailwind.css
@@ -4,7 +4,7 @@
 /*
  * Preflight (Tailwind's base reset) is intentionally not imported above:
  * Bootstrap 3/Limitless still owns the page-wide reset until Phase 2
- * (docs/adr/0001-ui-modernization-phasing.md) removes it entirely. Running
+ * (captain-coaster/captain-coaster#380) removes it entirely. Running
  * both resets at once would bleed into markup that isn't migrated yet.
  */
 
@@ -37,7 +37,11 @@
  * Only variants actually reachable in this app are included: alert-success/
  * -danger/-warning/-info (all reachable via addFlash()), plus
  * alert-styled-left/alert-arrow-left/alert-dismissible/alert-component/
- * alert-heading (the only modifiers referenced in templates).
+ * alert-heading (the only *styled* modifiers referenced in templates).
+ * "alert-bordered" is also referenced in templates (flashes.html.twig,
+ * connect/login.html.twig, registration/register.html.twig) but was never
+ * defined in the original LESS either -- pre-existing dead weight, not
+ * something this migration should invent styling for.
  * alert-primary and the .ui-pnotify integration were never used and are
  * dropped. "alert-error" (also a real addFlash() value) intentionally gets
  * no color rule below, matching the current (accidental) unstyled look —
@@ -210,7 +214,7 @@ button.close {
  * verified against the compiled output before relying on it.
  */
 .pagination {
-    @apply m-0 mt-0 -mb-1.5 inline-block rounded-[3px] pl-0;
+    @apply m-0 -mb-1.5 inline-block rounded-[3px] pl-0;
 }
 
 .pagination > li {

--- a/assets/styles/tailwind.css
+++ b/assets/styles/tailwind.css
@@ -1,0 +1,150 @@
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/utilities.css" layer(utilities);
+
+/*
+ * Preflight (Tailwind's base reset) is intentionally not imported above:
+ * Bootstrap 3/Limitless still owns the page-wide reset until Phase 2
+ * (docs/adr/0001-ui-modernization-phasing.md) removes it entirely. Running
+ * both resets at once would bleed into markup that isn't migrated yet.
+ */
+
+@source "../../templates";
+
+/*
+ * .alert — migrated from theme/bootstrap-limitless/alerts.less +
+ * bootstrap/less/alerts.less. Values below are copied from the compiled
+ * output of those two files (cascade already resolved), not re-derived
+ * from LESS variables, to guarantee an iso-visual result. Written as plain
+ * CSS rather than @apply: several rules here are pseudo-element icons
+ * (base64 SVG backgrounds) and precise absolute positioning that gain
+ * nothing from utility composition and are safer to keep as a verbatim
+ * copy of known-correct values.
+ *
+ * Only variants actually reachable in this app are included: alert-success/
+ * -danger/-warning/-info (all reachable via addFlash()), plus
+ * alert-styled-left/alert-arrow-left/alert-dismissible/alert-component/
+ * alert-heading (the only modifiers referenced in templates).
+ * alert-primary and the .ui-pnotify integration were never used and are
+ * dropped. "alert-error" (also a real addFlash() value) intentionally gets
+ * no color rule below, matching the current (accidental) unstyled look —
+ * "alert-error" was never a real Bootstrap/Limitless variant.
+ */
+@layer components {
+    .alert {
+        position: relative;
+        margin-bottom: 20px;
+        padding: 15px 20px;
+        border: 1px solid transparent;
+        border-radius: 3px;
+    }
+
+    .alert > p,
+    .alert > ul {
+        margin-bottom: 0;
+    }
+
+    .alert > p + p {
+        margin-top: 5px;
+    }
+
+    .alert-heading {
+        margin-top: 0;
+        margin-bottom: 5px;
+    }
+
+    .alert .close {
+        color: inherit;
+    }
+
+    .alert-dismissible,
+    .alert-dismissable {
+        padding-right: 35px;
+    }
+
+    .alert-dismissible .close,
+    .alert-dismissable .close {
+        position: relative;
+        top: -2px;
+        right: -21px;
+    }
+
+    .alert-success {
+        color: #205823;
+        background-color: #e8f5e9;
+        border-color: #4caf50;
+    }
+
+    .alert-info {
+        color: #00545c;
+        background-color: #e0f7fa;
+        border-color: #00bcd4;
+    }
+
+    .alert-warning {
+        color: #aa3510;
+        background-color: #fff3e0;
+        border-color: #ff9800;
+    }
+
+    .alert-danger {
+        color: #9c1f1f;
+        background-color: #fbe9e7;
+        border-color: #ff5722;
+    }
+
+    /* Only relevant paired with alert-styled-left, per the templates that use it. */
+    .alert-component[class*="alert-styled-"] {
+        background-color: #fff;
+    }
+
+    .alert-styled-left {
+        border-left-width: 44px;
+    }
+
+    /* Decorative icon in the colored left border of a styled alert. */
+    .alert[class*="alert-styled-"]:after {
+        content: "";
+        display: inline-block;
+        position: absolute;
+        top: 50%;
+        left: -44px;
+        width: 44px;
+        height: 16px;
+        margin-top: -8px;
+        line-height: 1;
+        background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBhcmlhLWhpZGRlbj0idHJ1ZSIgZGF0YS1zbG90PSJpY29uIj48cGF0aCBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGQ9Im0xMS4yNSAxMS4yNS4wNDEtLjAyYS43NS43NSAwIDAgMSAxLjA2My44NTJsLS43MDggMi44MzZhLjc1Ljc1IDAgMCAwIDEuMDYzLjg1M2wuMDQxLS4wMjFNMjEgMTJhOSA5IDAgMSAxLTE4IDAgOSA5IDAgMCAxIDE4IDBabS05LTMuNzVoLjAwOHYuMDA4SDEyVjguMjVaIi8+PC9zdmc+);
+        background-position: 50%;
+        background-repeat: no-repeat;
+        background-size: contain;
+    }
+
+    .alert[class*="alert-styled-"].alert-danger:after {
+        background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iY3VycmVudENvbG9yIiBhcmlhLWhpZGRlbj0idHJ1ZSIgZGF0YS1zbG90PSJpY29uIj48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMiAyLjI1Yy01LjM4NSAwLTkuNzUgNC4zNjUtOS43NSA5Ljc1czQuMzY1IDkuNzUgOS43NSA5Ljc1IDkuNzUtNC4zNjUgOS43NS05Ljc1UzE3LjM4NSAyLjI1IDEyIDIuMjVabS0xLjcyIDYuOTdhLjc1Ljc1IDAgMSAwLTEuMDYgMS4wNkwxMC45NCAxMmwtMS43MiAxLjcyYS43NS43NSAwIDEgMCAxLjA2IDEuMDZMMTIgMTMuMDZsMS43MiAxLjcyYS43NS43NSAwIDEgMCAxLjA2LTEuMDZMMTMuMDYgMTJsMS43Mi0xLjcyYS43NS43NSAwIDEgMC0xLjA2LTEuMDZMMTIgMTAuOTRsLTEuNzItMS43MloiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPjwvc3ZnPg==);
+    }
+
+    .alert[class*="alert-styled-"].alert-success:after {
+        background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iY3VycmVudENvbG9yIiBhcmlhLWhpZGRlbj0idHJ1ZSIgZGF0YS1zbG90PSJpY29uIj48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yLjI1IDEyYzAtNS4zODUgNC4zNjUtOS43NSA5Ljc1LTkuNzVzOS43NSA0LjM2NSA5Ljc1IDkuNzUtNC4zNjUgOS43NS05Ljc1IDkuNzVTMi4yNSAxNy4zODUgMi4yNSAxMlptMTMuMzYtMS44MTRhLjc1Ljc1IDAgMSAwLTEuMjItLjg3MmwtMy4yMzYgNC41M0w5LjUzIDEyLjIyYS43NS43NSAwIDAgMC0xLjA2IDEuMDZsMi4yNSAyLjI1YS43NS43NSAwIDAgMCAxLjE0LS4wOTRsMy43NS01LjI1WiIgY2xpcC1ydWxlPSJldmVub2RkIi8+PC9zdmc+);
+    }
+
+    .alert[class*="alert-styled-"].alert-warning:after {
+        background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBhcmlhLWhpZGRlbj0idHJ1ZSIgZGF0YS1zbG90PSJpY29uIj48cGF0aCBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGQ9Ik0xMiA5djMuNzVtLTkuMzAzIDMuMzc2Yy0uODY2IDEuNS4yMTcgMy4zNzQgMS45NDggMy4zNzRoMTQuNzFjMS43MyAwIDIuODEzLTEuODc0IDEuOTQ4LTMuMzc0TDEzLjk0OSAzLjM3OGMtLjg2Ni0xLjUtMy4wMzItMS41LTMuODk4IDBMMi42OTcgMTYuMTI2Wk0xMiAxNS43NWguMDA3di4wMDhIMTJ2LS4wMDhaIi8+PC9zdmc+);
+    }
+
+    .alert[class*="alert-styled-"].alert-info:after {
+        background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBhcmlhLWhpZGRlbj0idHJ1ZSIgZGF0YS1zbG90PSJpY29uIj48cGF0aCBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGQ9Im0xMS4yNSAxMS4yNS4wNDEtLjAyYS43NS43NSAwIDAgMSAxLjA2My44NTJsLS43MDggMi44MzZhLjc1Ljc1IDAgMCAwIDEuMDYzLjg1M2wuMDQxLS4wMjFNMjEgMTJhOSA5IDAgMSAxLTE4IDAgOSA5IDAgMCAxIDE4IDBabS05LTMuNzVoLjAwOHYuMDA4SDEyVjguMjVaIi8+PC9zdmc+);
+    }
+
+    /* Small triangle notch at the edge of the colored left border. */
+    .alert[class*="alert-arrow-"]:before {
+        content: "";
+        display: inline-block;
+        position: absolute;
+        top: 50%;
+        left: 0;
+        margin-top: -5px;
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        border-left: 5px solid;
+        border-left-color: inherit;
+    }
+}

--- a/assets/styles/tailwind.css
+++ b/assets/styles/tailwind.css
@@ -195,7 +195,7 @@ button.close {
 }
 
 .modal-header .close {
-    @apply absolute top-1/2 right-5 mt-0;
+    @apply absolute top-1/2 right-[20px] mt-0;
 }
 
 .modal-body .close {
@@ -214,7 +214,7 @@ button.close {
  * verified against the compiled output before relying on it.
  */
 .pagination {
-    @apply m-0 -mb-1.5 inline-block rounded-[3px] pl-0;
+    @apply m-0 -mb-[6px] inline-block rounded-[3px] pl-0;
 }
 
 .pagination > li {

--- a/assets/styles/tailwind.css
+++ b/assets/styles/tailwind.css
@@ -11,6 +11,20 @@
 @source "../../templates";
 
 /*
+ * Everything below is intentionally NOT inside `@layer components`.
+ * CSS cascade layers always lose to unlayered rules, regardless of
+ * selector specificity — and the LESS Bootstrap/Limitless files still
+ * imported into app.less are unlayered plain CSS. `@layer components`
+ * silently broke `.pagination > li > a`'s background here: Bootstrap's
+ * own `a { background-color: transparent }` reset (scaffolding.less) has
+ * lower specificity but, being unlayered, still won over our layered,
+ * more specific rule. Written as plain top-level rules instead, so normal
+ * specificity/source-order decides against whatever Bootstrap CSS hasn't
+ * been migrated away yet — which is what we want during the transition.
+ * `@apply` works the same either way, layer or not.
+ */
+
+/*
  * .alert — migrated from theme/bootstrap-limitless/alerts.less +
  * bootstrap/less/alerts.less. Values below are copied from the compiled
  * output of those two files (cascade already resolved), not re-derived
@@ -29,122 +43,250 @@
  * no color rule below, matching the current (accidental) unstyled look —
  * "alert-error" was never a real Bootstrap/Limitless variant.
  */
-@layer components {
-    .alert {
-        position: relative;
-        margin-bottom: 20px;
-        padding: 15px 20px;
-        border: 1px solid transparent;
-        border-radius: 3px;
-    }
-
-    .alert > p,
-    .alert > ul {
-        margin-bottom: 0;
-    }
-
-    .alert > p + p {
-        margin-top: 5px;
-    }
-
-    .alert-heading {
-        margin-top: 0;
-        margin-bottom: 5px;
-    }
-
-    .alert .close {
-        color: inherit;
-    }
-
-    .alert-dismissible,
-    .alert-dismissable {
-        padding-right: 35px;
-    }
-
-    .alert-dismissible .close,
-    .alert-dismissable .close {
-        position: relative;
-        top: -2px;
-        right: -21px;
-    }
-
-    .alert-success {
-        color: #205823;
-        background-color: #e8f5e9;
-        border-color: #4caf50;
-    }
-
-    .alert-info {
-        color: #00545c;
-        background-color: #e0f7fa;
-        border-color: #00bcd4;
-    }
-
-    .alert-warning {
-        color: #aa3510;
-        background-color: #fff3e0;
-        border-color: #ff9800;
-    }
-
-    .alert-danger {
-        color: #9c1f1f;
-        background-color: #fbe9e7;
-        border-color: #ff5722;
-    }
-
-    /* Only relevant paired with alert-styled-left, per the templates that use it. */
-    .alert-component[class*="alert-styled-"] {
-        background-color: #fff;
-    }
-
-    .alert-styled-left {
-        border-left-width: 44px;
-    }
-
-    /* Decorative icon in the colored left border of a styled alert. */
-    .alert[class*="alert-styled-"]:after {
-        content: "";
-        display: inline-block;
-        position: absolute;
-        top: 50%;
-        left: -44px;
-        width: 44px;
-        height: 16px;
-        margin-top: -8px;
-        line-height: 1;
-        background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBhcmlhLWhpZGRlbj0idHJ1ZSIgZGF0YS1zbG90PSJpY29uIj48cGF0aCBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGQ9Im0xMS4yNSAxMS4yNS4wNDEtLjAyYS43NS43NSAwIDAgMSAxLjA2My44NTJsLS43MDggMi44MzZhLjc1Ljc1IDAgMCAwIDEuMDYzLjg1M2wuMDQxLS4wMjFNMjEgMTJhOSA5IDAgMSAxLTE4IDAgOSA5IDAgMCAxIDE4IDBabS05LTMuNzVoLjAwOHYuMDA4SDEyVjguMjVaIi8+PC9zdmc+);
-        background-position: 50%;
-        background-repeat: no-repeat;
-        background-size: contain;
-    }
-
-    .alert[class*="alert-styled-"].alert-danger:after {
-        background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iY3VycmVudENvbG9yIiBhcmlhLWhpZGRlbj0idHJ1ZSIgZGF0YS1zbG90PSJpY29uIj48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMiAyLjI1Yy01LjM4NSAwLTkuNzUgNC4zNjUtOS43NSA5Ljc1czQuMzY1IDkuNzUgOS43NSA5Ljc1IDkuNzUtNC4zNjUgOS43NS05Ljc1UzE3LjM4NSAyLjI1IDEyIDIuMjVabS0xLjcyIDYuOTdhLjc1Ljc1IDAgMSAwLTEuMDYgMS4wNkwxMC45NCAxMmwtMS43MiAxLjcyYS43NS43NSAwIDEgMCAxLjA2IDEuMDZMMTIgMTMuMDZsMS43MiAxLjcyYS43NS43NSAwIDEgMCAxLjA2LTEuMDZMMTMuMDYgMTJsMS43Mi0xLjcyYS43NS43NSAwIDEgMC0xLjA2LTEuMDZMMTIgMTAuOTRsLTEuNzItMS43MloiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPjwvc3ZnPg==);
-    }
-
-    .alert[class*="alert-styled-"].alert-success:after {
-        background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iY3VycmVudENvbG9yIiBhcmlhLWhpZGRlbj0idHJ1ZSIgZGF0YS1zbG90PSJpY29uIj48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yLjI1IDEyYzAtNS4zODUgNC4zNjUtOS43NSA5Ljc1LTkuNzVzOS43NSA0LjM2NSA5Ljc1IDkuNzUtNC4zNjUgOS43NS05Ljc1IDkuNzVTMi4yNSAxNy4zODUgMi4yNSAxMlptMTMuMzYtMS44MTRhLjc1Ljc1IDAgMSAwLTEuMjItLjg3MmwtMy4yMzYgNC41M0w5LjUzIDEyLjIyYS43NS43NSAwIDAgMC0xLjA2IDEuMDZsMi4yNSAyLjI1YS43NS43NSAwIDAgMCAxLjE0LS4wOTRsMy43NS01LjI1WiIgY2xpcC1ydWxlPSJldmVub2RkIi8+PC9zdmc+);
-    }
-
-    .alert[class*="alert-styled-"].alert-warning:after {
-        background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBhcmlhLWhpZGRlbj0idHJ1ZSIgZGF0YS1zbG90PSJpY29uIj48cGF0aCBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGQ9Ik0xMiA5djMuNzVtLTkuMzAzIDMuMzc2Yy0uODY2IDEuNS4yMTcgMy4zNzQgMS45NDggMy4zNzRoMTQuNzFjMS43MyAwIDIuODEzLTEuODc0IDEuOTQ4LTMuMzc0TDEzLjk0OSAzLjM3OGMtLjg2Ni0xLjUtMy4wMzItMS41LTMuODk4IDBMMi42OTcgMTYuMTI2Wk0xMiAxNS43NWguMDA3di4wMDhIMTJ2LS4wMDhaIi8+PC9zdmc+);
-    }
-
-    .alert[class*="alert-styled-"].alert-info:after {
-        background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBhcmlhLWhpZGRlbj0idHJ1ZSIgZGF0YS1zbG90PSJpY29uIj48cGF0aCBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGQ9Im0xMS4yNSAxMS4yNS4wNDEtLjAyYS43NS43NSAwIDAgMSAxLjA2My44NTJsLS43MDggMi44MzZhLjc1Ljc1IDAgMCAwIDEuMDYzLjg1M2wuMDQxLS4wMjFNMjEgMTJhOSA5IDAgMSAxLTE4IDAgOSA5IDAgMCAxIDE4IDBabS05LTMuNzVoLjAwOHYuMDA4SDEyVjguMjVaIi8+PC9zdmc+);
-    }
-
-    /* Small triangle notch at the edge of the colored left border. */
-    .alert[class*="alert-arrow-"]:before {
-        content: "";
-        display: inline-block;
-        position: absolute;
-        top: 50%;
-        left: 0;
-        margin-top: -5px;
-        border-top: 5px solid transparent;
-        border-bottom: 5px solid transparent;
-        border-left: 5px solid;
-        border-left-color: inherit;
-    }
+.alert {
+    position: relative;
+    margin-bottom: 20px;
+    padding: 15px 20px;
+    border: 1px solid transparent;
+    border-radius: 3px;
 }
+
+.alert > p,
+.alert > ul {
+    margin-bottom: 0;
+}
+
+.alert > p + p {
+    margin-top: 5px;
+}
+
+.alert-heading {
+    margin-top: 0;
+    margin-bottom: 5px;
+}
+
+.alert .close {
+    color: inherit;
+}
+
+.alert-dismissible,
+.alert-dismissable {
+    padding-right: 35px;
+}
+
+.alert-dismissible .close,
+.alert-dismissable .close {
+    position: relative;
+    top: -2px;
+    right: -21px;
+}
+
+.alert-success {
+    color: #205823;
+    background-color: #e8f5e9;
+    border-color: #4caf50;
+}
+
+.alert-info {
+    color: #00545c;
+    background-color: #e0f7fa;
+    border-color: #00bcd4;
+}
+
+.alert-warning {
+    color: #aa3510;
+    background-color: #fff3e0;
+    border-color: #ff9800;
+}
+
+.alert-danger {
+    color: #9c1f1f;
+    background-color: #fbe9e7;
+    border-color: #ff5722;
+}
+
+/* Only relevant paired with alert-styled-left, per the templates that use it. */
+.alert-component[class*="alert-styled-"] {
+    background-color: #fff;
+}
+
+.alert-styled-left {
+    border-left-width: 44px;
+}
+
+/* Decorative icon in the colored left border of a styled alert. */
+.alert[class*="alert-styled-"]:after {
+    content: "";
+    display: inline-block;
+    position: absolute;
+    top: 50%;
+    left: -44px;
+    width: 44px;
+    height: 16px;
+    margin-top: -8px;
+    line-height: 1;
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBhcmlhLWhpZGRlbj0idHJ1ZSIgZGF0YS1zbG90PSJpY29uIj48cGF0aCBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGQ9Im0xMS4yNSAxMS4yNS4wNDEtLjAyYS43NS43NSAwIDAgMSAxLjA2My44NTJsLS43MDggMi44MzZhLjc1Ljc1IDAgMCAwIDEuMDYzLjg1M2wuMDQxLS4wMjFNMjEgMTJhOSA5IDAgMSAxLTE4IDAgOSA5IDAgMCAxIDE4IDBabS05LTMuNzVoLjAwOHYuMDA4SDEyVjguMjVaIi8+PC9zdmc+);
+    background-position: 50%;
+    background-repeat: no-repeat;
+    background-size: contain;
+}
+
+.alert[class*="alert-styled-"].alert-danger:after {
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iY3VycmVudENvbG9yIiBhcmlhLWhpZGRlbj0idHJ1ZSIgZGF0YS1zbG90PSJpY29uIj48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMiAyLjI1Yy01LjM4NSAwLTkuNzUgNC4zNjUtOS43NSA5Ljc1czQuMzY1IDkuNzUgOS43NSA5Ljc1IDkuNzUtNC4zNjUgOS43NS05Ljc1UzE3LjM4NSAyLjI1IDEyIDIuMjVabS0xLjcyIDYuOTdhLjc1Ljc1IDAgMSAwLTEuMDYgMS4wNkwxMC45NCAxMmwtMS43MiAxLjcyYS43NS43NSAwIDEgMCAxLjA2IDEuMDZMMTIgMTMuMDZsMS43MiAxLjcyYS43NS43NSAwIDEgMCAxLjA2LTEuMDZMMTMuMDYgMTJsMS43Mi0xLjcyYS43NS43NSAwIDEgMC0xLjA2LTEuMDZMMTIgMTAuOTRsLTEuNzItMS43MloiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPjwvc3ZnPg==);
+}
+
+.alert[class*="alert-styled-"].alert-success:after {
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iY3VycmVudENvbG9yIiBhcmlhLWhpZGRlbj0idHJ1ZSIgZGF0YS1zbG90PSJpY29uIj48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yLjI1IDEyYzAtNS4zODUgNC4zNjUtOS43NSA5Ljc1LTkuNzVzOS43NSA0LjM2NSA5Ljc1IDkuNzUtNC4zNjUgOS43NS05Ljc1IDkuNzVTMi4yNSAxNy4zODUgMi4yNSAxMlptMTMuMzYtMS44MTRhLjc1Ljc1IDAgMSAwLTEuMjItLjg3MmwtMy4yMzYgNC41M0w5LjUzIDEyLjIyYS43NS43NSAwIDAgMC0xLjA2IDEuMDZsMi4yNSAyLjI1YS43NS43NSAwIDAgMCAxLjE0LS4wOTRsMy43NS01LjI1WiIgY2xpcC1ydWxlPSJldmVub2RkIi8+PC9zdmc+);
+}
+
+.alert[class*="alert-styled-"].alert-warning:after {
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBhcmlhLWhpZGRlbj0idHJ1ZSIgZGF0YS1zbG90PSJpY29uIj48cGF0aCBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGQ9Ik0xMiA5djMuNzVtLTkuMzAzIDMuMzc2Yy0uODY2IDEuNS4yMTcgMy4zNzQgMS45NDggMy4zNzRoMTQuNzFjMS43MyAwIDIuODEzLTEuODc0IDEuOTQ4LTMuMzc0TDEzLjk0OSAzLjM3OGMtLjg2Ni0xLjUtMy4wMzItMS41LTMuODk4IDBMMi42OTcgMTYuMTI2Wk0xMiAxNS43NWguMDA3di4wMDhIMTJ2LS4wMDhaIi8+PC9zdmc+);
+}
+
+.alert[class*="alert-styled-"].alert-info:after {
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBhcmlhLWhpZGRlbj0idHJ1ZSIgZGF0YS1zbG90PSJpY29uIj48cGF0aCBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGQ9Im0xMS4yNSAxMS4yNS4wNDEtLjAyYS43NS43NSAwIDAgMSAxLjA2My44NTJsLS43MDggMi44MzZhLjc1Ljc1IDAgMCAwIDEuMDYzLjg1M2wuMDQxLS4wMjFNMjEgMTJhOSA5IDAgMSAxLTE4IDAgOSA5IDAgMCAxIDE4IDBabS05LTMuNzVoLjAwOHYuMDA4SDEyVjguMjVaIi8+PC9zdmc+);
+}
+
+/* Small triangle notch at the edge of the colored left border. */
+.alert[class*="alert-arrow-"]:before {
+    content: "";
+    display: inline-block;
+    position: absolute;
+    top: 50%;
+    left: 0;
+    margin-top: -5px;
+    border-top: 5px solid transparent;
+    border-bottom: 5px solid transparent;
+    border-left: 5px solid;
+    border-left-color: inherit;
+}
+
+/*
+ * .close — migrated from theme/bootstrap-limitless/close.less +
+ * bootstrap/less/close.less. Used standalone (dismiss a review-report
+ * modal) and inside .alert (that context — .alert .close,
+ * .alert-dismissible .close — already lives above, owned by the alert
+ * migration). Two upstream rules in modals.less
+ * (`.modal-header[class*="bg-"] .close` and the .modal-content
+ * variant) target this class for bg-tinted modal headers; no template
+ * uses one, so they're dead in practice and intentionally left
+ * untouched in modals.less until that file's own migration.
+ *
+ * @apply used here (unlike .alert) since every value maps to a plain
+ * Tailwind utility or a simple arbitrary one — nothing pseudo-element
+ * or icon-shaped that would fight the utility syntax.
+ */
+.close {
+    @apply float-right text-[19.5px] font-light leading-none text-black opacity-60;
+}
+
+.close:hover,
+.close:focus {
+    @apply cursor-pointer text-black no-underline opacity-100;
+    outline: 0;
+}
+
+button.close {
+    @apply cursor-pointer border-0 bg-transparent p-0 appearance-none;
+}
+
+.modal-header .close {
+    @apply absolute top-1/2 right-5 mt-0;
+}
+
+.modal-body .close {
+    margin-top: 0 !important;
+}
+
+/*
+ * .pagination — migrated from theme/bootstrap-limitless/pagination.less +
+ * bootstrap/less/pagination.less. Only the base + .pagination-sm variant
+ * are included (the only ones referenced in templates); pagination-lg/
+ * -xs/-flat/-rounded/-separated were never used and are dropped.
+ * Renders through two near-identical KNP pagination templates
+ * (custom + the bootstrap_v4 override) whose `.page-item`/`.page-link`
+ * classes carry no CSS at all in this app (Bootstrap 3 styles this
+ * structurally via `.pagination > li > a`, not by those class names) —
+ * verified against the compiled output before relying on it.
+ */
+.pagination {
+    @apply m-0 mt-0 -mb-1.5 inline-block rounded-[3px] pl-0;
+}
+
+.pagination > li {
+    display: inline;
+}
+
+.pagination > li > a,
+.pagination > li > span {
+    @apply relative float-left border border-[#ddd] bg-white text-center text-[#333];
+    min-width: 36px;
+    padding: 7px 12px;
+    line-height: 1.53846;
+    text-decoration: none;
+    margin-left: -1px;
+}
+
+.pagination > li > a:hover,
+.pagination > li > span:hover,
+.pagination > li > a:focus,
+.pagination > li > span:focus {
+    @apply z-2 bg-[#f5f5f5] text-[#333];
+    border-color: #ddd;
+}
+
+.pagination > li:first-child > a,
+.pagination > li:first-child > span {
+    @apply ml-0 rounded-l-[3px];
+}
+
+.pagination > li:last-child > a,
+.pagination > li:last-child > span {
+    @apply rounded-r-[3px];
+}
+
+.pagination > .active > a,
+.pagination > .active > span,
+.pagination > .active > a:hover,
+.pagination > .active > span:hover,
+.pagination > .active > a:focus,
+.pagination > .active > span:focus {
+    @apply z-3 cursor-default text-white;
+    background-color: #2196f3;
+    border-color: #2196f3;
+}
+
+.pagination > .disabled > span,
+.pagination > .disabled > span:hover,
+.pagination > .disabled > span:focus,
+.pagination > .disabled > a,
+.pagination > .disabled > a:hover,
+.pagination > .disabled > a:focus {
+    @apply cursor-not-allowed bg-transparent text-[#bbb];
+    border-color: #ddd;
+}
+
+.pagination-sm > li > a,
+.pagination-sm > li > span {
+    @apply text-[12px];
+    padding: 6px 11px;
+    line-height: 1.66667;
+    min-width: 34px;
+}
+
+.pagination-sm > li:first-child > a,
+.pagination-sm > li:first-child > span {
+    @apply rounded-l-[2px];
+}
+
+.pagination-sm > li:last-child > a,
+.pagination-sm > li:last-child > span {
+    @apply rounded-r-[2px];
+}
+
+/*
+ * .pager (theme/bootstrap-limitless/pager.less + bootstrap/less/pager.less)
+ * is intentionally NOT migrated: grepping templates/ and src/ found zero
+ * uses of "pager" anywhere in this app. Both files are deleted from
+ * app.less with no Tailwind replacement.
+ */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "build+vite-migration",
+  "name": "css+tailwind-labels",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -16,11 +16,13 @@
         "@rollup/plugin-inject": "^5.0.5",
         "@symfony/reprise": "^1.1.1",
         "@symfony/ux-translator": "file:vendor/symfony/ux-translator/assets",
+        "@tailwindcss/vite": "^4.3.3",
         "autoprefixer": "^10.4.21",
         "intl-messageformat": "^10.5.11",
         "less": "^4.4.2",
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
+        "tailwindcss": "^4.3.3",
         "vite": "^8.2.2"
       }
     },
@@ -774,6 +776,563 @@
       "resolved": "vendor/symfony/ux-translator/assets",
       "link": true
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "tailwindcss": "4.3.3"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -1274,6 +1833,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/errno": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
@@ -1383,8 +1956,7 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -1481,6 +2053,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/jquery": {
@@ -2491,6 +3073,27 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
     "@rollup/plugin-inject": "^5.0.5",
     "@symfony/reprise": "^1.1.1",
     "@symfony/ux-translator": "file:vendor/symfony/ux-translator/assets",
+    "@tailwindcss/vite": "^4.3.3",
     "autoprefixer": "^10.4.21",
     "intl-messageformat": "^10.5.11",
     "less": "^4.4.2",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
+    "tailwindcss": "^4.3.3",
     "vite": "^8.2.2"
   },
   "license": "UNLICENSED",

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import Symfony from '@symfony/reprise/vite';
 import inject from '@rollup/plugin-inject';
+import tailwindcss from '@tailwindcss/vite';
 
 // Single source of truth for the versioned vendor/ path below and the
 // matching setWorkerUrl() call in map_controller.js — keeps the two in
@@ -49,6 +50,7 @@ export default defineConfig(({ command }) => ({
     },
 
     plugins: [
+        tailwindcss(),
         Symfony({
             stimulus: 'assets/controllers.json',
             integrity: {


### PR DESCRIPTION
## Summary

First PR of Phase 2 (#380, part of the UI modernization epic #375): wires up `@tailwindcss/vite`, Preflight disabled (Bootstrap still owns the page-wide reset until the whole phase is done — see `docs/adr/0001-ui-modernization-phasing.md`). Migrates the first 4 components, chosen and verified one at a time.

**Methodology, established here for the rest of the phase**: before picking a LESS file, check it's a genuine leaf two ways — no `@import` from other component files, *and* no cross-file *selector* coupling in the compiled CSS. The first check alone is insufficient: `labels.less` looked isolated by `@import` but its `.label`/`.badge` selectors are targeted by `navbar.less`/`dropdowns.less`/`panels.less`/the sidebar layout for positioning — migrating it would have silently broken the navbar notification badge. Switched to `alerts.less` (zero external references, confirmed) instead. Values are always copied from the *compiled* CSS (cascade already resolved) rather than re-derived from LESS variables, to guarantee an iso-visual result — including base64 SVG icons, extracted programmatically rather than retyped.

**Components migrated**:
- `.alert`: `alert-success/-danger/-warning/-info` (all reachable via `addFlash()`), `alert-styled-left`/`alert-arrow-left`/`alert-dismissible`/`alert-component`/`alert-heading` (the only modifiers referenced in templates). `alert-primary` and the `.ui-pnotify` integration were dead code, dropped. `alert-error` (a real `addFlash()` value) intentionally keeps its current accidental unstyled look.
- `.pagination`: base + `.pagination-sm` (the only variant referenced in templates). Renders through two near-identical KNP pagination templates whose `.page-item`/`.page-link` classes carry no CSS at all in this app — Bootstrap 3 styles it structurally via `.pagination > li > a`, verified against the compiled output before relying on it.
- `.close`: used standalone (the review-report modal) and inside `.alert`. Two `modals.less` rules target it for bg-tinted modal headers; no template uses one, left untouched there until `modals` itself is migrated.
- `.pager`: **not migrated** — zero uses anywhere in `templates/` or `src/`, so both LESS files are just deleted with no replacement.

**Zero Twig template changes** across all four — class names are unchanged, only the CSS engine behind them moved from LESS to Tailwind.

**Bug caught and fixed while verifying this batch** (in the `.alert` migration too): everything was originally wrapped in `@layer components`. CSS cascade layers always lose to unlayered rules regardless of selector specificity, and the remaining Bootstrap/Limitless LESS is unlayered — Bootstrap's own `a { background-color: transparent }` (`scaffolding.less`) was silently beating our more specific `.pagination > li > a` rule, so non-active pagination links rendered with a transparent background instead of white. Moved everything to plain top-level rules instead; `@apply` works identically with or without the layer wrapper. This is now the convention for the rest of the phase.

## Test plan
- [x] Compiled CSS diffed property-by-property against the pre-migration build for every migrated selector — identical values, byte-identical icon data URIs
- [x] Computed styles re-verified directly in the browser (`getComputedStyle`) after the `@layer` fix, not just the CSS source text
- [x] `vendor/bin/phpunit`, `vendor/bin/phpstan analyse`, `vendor/bin/php-cs-fixer fix --dry-run` all pass
- [x] Manually verified in a mobile viewport (390×844): homepage's `alert-info`, an invalid-login `alert-danger`, `/en/users`' info alert, `/en/ranking/` pagination (active/hover/disabled/first/last states), the review-report modal's close button — 0 console errors throughout