### PR TITLE
fix(css): stop Tailwind's collapse utility from hiding the navbar

### DIFF
--- a/assets/styles/tailwind.css
+++ b/assets/styles/tailwind.css
@@ -11,6 +11,23 @@
 @source "../../templates";
 
 /*
+ * Tailwind's built-in `.collapse` utility (visibility: collapse, meant for
+ * table rows) collides with Bootstrap 3's unrelated `.collapse` JS-toggle
+ * class (component-animations.less) -- @source above picks up the literal
+ * token from templates/navbar.html.twig's `navbar-collapse collapse` div.
+ * The layered utility can't override Bootstrap's unlayered `display`, but
+ * `visibility` is a property Bootstrap never sets there, so it applied
+ * unopposed and silently hid the whole #navbar-mobile block (both the
+ * left-side toggle and the right-side user/notifications dropdown) on
+ * every viewport -- visibility:collapse on a non-table element is
+ * equivalent to hidden per spec. Unlayered here so it wins the same way
+ * the rules below do.
+ */
+.collapse {
+    visibility: visible;
+}
+
+/*
  * Everything below is intentionally NOT inside `@layer components`.
  * CSS cascade layers always lose to unlayered rules, regardless of
  * selector specificity — and the LESS Bootstrap/Limitless files still


### PR DESCRIPTION
## Summary

PR #382 wired up Tailwind's `@source` scanning of `templates/` for the first time. Tailwind ships a built-in `.collapse` utility (`visibility: collapse`, meant for table rows) that collided with Bootstrap 3's unrelated `.collapse` JS-toggle class -- the scanner picked up the literal `collapse` token from `templates/navbar.html.twig`'s `navbar-collapse collapse` div.

The layered Tailwind utility can't override Bootstrap's unlayered `display` rules, but it sets `visibility`, a property Bootstrap never touches on that selector, so it applied unopposed. `visibility: collapse` on a non-table element is equivalent to `hidden` per spec, which silently hid `#navbar-mobile` (the left-side nav toggle and the right-side user/notifications dropdown) on every viewport in production -- root cause of the rollback after #382's deploy.

## Fix

An unlayered `.collapse { visibility: visible }` override in `tailwind.css`, following the file's existing convention (unlayered always wins over Tailwind's layered utilities, documented in the file's own comments from the `.pagination` fix in #382).

## Test plan

- [x] `npm run build` succeeds
- [x] Verified against compiled output: `@layer utilities{.collapse{visibility:collapse}}` followed by the unlayered `.collapse{visibility:visible}` override
- [ ] Deploy to prod and confirm the navbar/sidebar toggle renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jnDuQAtNShE33eFtfQb9z