### PR TITLE
docs(agents): add agent-operating conventions, fix worktree provisioning docs

### DIFF
--- a/.claude/skills/dev-environment/SKILL.md
+++ b/.claude/skills/dev-environment/SKILL.md
@@ -11,15 +11,12 @@ Canonical path is `symfony server:start`. `docker-compose.full.yml` (nginx + php
 
 1. **Provision the checkout, if it's a worktree.** Main checkout: nothing to do, skip to step 2. In a worktree, do this once (it's idempotent — check each condition before acting):
 
-   - **`.env.local`**: it must end up a symlink to the main checkout's copy (find the main checkout with `git rev-parse --path-format=absolute --git-common-dir`, then its parent). If it's already that symlink, leave it. If it's a regular file identical to the main copy, replace it with the symlink. If it's a regular file that *differs*, or a symlink pointing anywhere else, stop and ask the user rather than discarding it — it may hold worktree-specific secrets. Never edit `.env.local` itself.
+   - **`.env.local`**: `.worktreeinclude` (repo root) lists it, so `EnterWorktree` copies it into the new worktree automatically as a regular file — nothing to do here. It's a point-in-time snapshot, not a live link: it won't pick up later edits to the main checkout's copy, and it holds live secrets, so never edit it directly in either place from an agent session.
    - **`.env.dev.local`**: write it with `DATABASE_URL` copied from `.env.local` but with the database name swapped (below). `REDIS_URL` is left as-is — worktrees share the Redis cache. Symfony loads this file after `.env.local`, so it wins.
-   - **Database**: pick a name `captain_<slug>`, where `<slug>` is the worktree directory name, lowercased, with anything outside `[a-z0-9_]` collapsed to `_`. Clone it from `captain` (shared containers, so this works from any worktree):
+   - **Database**: pick a name `captain_<slug>`, where `<slug>` is the worktree directory name, lowercased, with anything outside `[a-z0-9_]` collapsed to `_`. Clone it from `captain` (shared containers, so this works from any worktree). Create the database first (`CREATE DATABASE \`$db\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`) — see root password in `docker-compose.yml`. If it already exists, leave it; this is a one-time clone, not a resync. Dump to a scratch file and reload from it, rather than piping `mariadb-dump` straight into `mariadb` through `docker exec ... sh -c '... | ...'` — a worktree-isolated agent session's command guard refuses that piped form:
 
-         docker exec db-captain sh -c \
-           'mariadb-dump --single-transaction --routines --events -uroot -p"$MYSQL_ROOT_PASSWORD" captain \
-            | mariadb -uroot -p"$MYSQL_ROOT_PASSWORD" '"$db"
-
-     Create the database first (`CREATE DATABASE \`$db\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`) — see root password in `docker-compose.yml`. If it already exists, leave it; this is a one-time clone, not a resync.
+         docker exec db-captain mariadb-dump --single-transaction --routines --events -uroot -p"$MYSQL_ROOT_PASSWORD" captain > /tmp/captain_dump.sql
+         docker exec -i db-captain mariadb -uroot -p"$MYSQL_ROOT_PASSWORD" "$db" < /tmp/captain_dump.sql
 
 2. **Start the Symfony server** from the current checkout:
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .idea
 /screenshots/
+/.playwright-mcp/
 
 # runtime maintenance-mode toggle, copied in/out by deploy.sh — not source
 /public/maintenance.html
@@ -35,7 +36,10 @@ phpstan.neon
 
 # Local scratch: session working documents (specs, plans), runbooks, incident
 # notes. Never committed — this is a public repo.
-/docs/
+/docs/*
+# ...except agent-operating conventions (label/tool mappings, domain-doc
+# pointers) — no sensitive content, same category as CLAUDE.md itself.
+!/docs/agents
 
 ###> symfony/reprise ###
 /node_modules/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,1 @@
+.env.local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ PHP follows the `@Symfony` + `@Symfony:risky` + `@PHP82Migration:risky` + `@PHP8
 
 ## Git workflow
 
-- Create worktrees with the built-in `EnterWorktree` tool, not `git worktree add`. Never edit `.env.local` — it holds live secrets and is shared by symlink across worktrees.
+- Create worktrees with the built-in `EnterWorktree` tool, not `git worktree add`. `.worktreeinclude` makes it copy `.env.local` into each new worktree automatically. Never edit `.env.local` — it holds live secrets, and per-worktree copies are point-in-time snapshots, not kept in sync with each other.
 - There is no pre-commit hook — run `vendor/bin/php-cs-fixer fix` and `vendor/bin/phpunit` yourself before committing.
 - Redis, MariaDB and Adminer run in shared containers. Never `docker compose down`.
 - One PR per feature — keep it small where the change allows.
@@ -130,3 +130,17 @@ vendor/bin/php-cs-fixer fix
 ### Verifying UI changes
 
 A dev server runs locally — use the Playwright MCP tools against it to verify front-end work. The port varies per worktree (see `.claude/skills/dev-environment/SKILL.md`), so read the actual URL rather than assuming `localhost:8000`. Resize to a mobile viewport (e.g. 390×844) first, since ~80% of usage is mobile.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues (`captain-coaster/captain-coaster`), via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default canonical roles, except `wontfix` reuses the existing `status/wontfix` label. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists: it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`**: read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal: either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders), but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,56 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## This repo is public
+
+`captain-coaster/captain-coaster` is a public repo — every issue, comment, and label is visible to anyone, not just contributors. Before posting to the tracker, strip out anything more "internal ops" than "roadmap":
+
+- Real usage numbers (user counts, opt-in/engagement rates, growth figures).
+- Production infrastructure specifics: hosting details, deploy mechanics, process-supervision setup, credentials or endpoints of any kind.
+
+Architecture and technology choices (frameworks, libraries, the general shape of a design) are fine to post — they're already implied by this file's own tech-stack section. It's *operational specifics and real metrics* that stay out.
+
+Keep that detail in Claude's memory (or a private note) instead, referencing the issue number so the two stay linked. If a plan genuinely needs a private home going forward (recurring internal-only planning, not just one issue), consider a private companion repo rather than routing around this rule case by case.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either: resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder/map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder/map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder/<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,46 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage **state** roles and two canonical **category** roles. This file maps those roles to the actual label strings and fields used in this repo's issue tracker.
+
+## State roles
+
+All five states now live under the `status/` prefix, alongside the pre-existing workflow labels — one unified axis instead of two overlapping ones.
+
+| Label in mattpocock/skills | Label in our tracker      | Meaning                                   |
+| --------------------------- | -------------------------- | ------------------------------------------ |
+| `needs-triage`              | `status/needs-triage`      | Maintainer needs to evaluate this issue   |
+| `needs-info`                | `status/needs-info`        | Waiting on reporter for more information  |
+| `ready-for-agent`           | `status/ready-for-agent`   | Fully specified, ready for an AFK agent   |
+| `ready-for-human`           | `status/ready-for-human`   | Requires human implementation             |
+| `wontfix`                   | `status/wontfix`           | Will not be actioned                      |
+
+`status/to do` was retired (2026-09-10): once triage exists, "not started" is already implied by `status/needs-triage` / `status/ready-for-agent` / `status/ready-for-human` before work begins. `status/in progress`, `status/to review`, and `status/done` stay — they track real work state (someone is actively coding, PR is up, merged/shipped) once an issue has moved past triage, which the triage-state labels don't capture.
+
+`status/outdated` was folded into `status/wontfix` (2026-09-10): both meant "not being actioned," just with a different flavor of reason — that reason belongs in the closing comment, not a separate label. `status/duplicate` stays, since it's a genuinely different claim (this exact ask already has a home elsewhere, not a decision to skip it).
+
+**`ready-for-human` means implementation, not review.** It says a human (not an AFK agent) needs to write the code — because of a judgment call, external access, a design decision, or manual testing. The moment an issue has an open PR against it, implementation has started: swap `status/ready-for-human` for `status/to review` (or `status/in progress` if the PR isn't up yet but someone's actively coding) instead of leaving the triage-state label in place. Check for an open PR before applying `ready-for-human` to an issue that looks active.
+
+## Category roles
+
+Category uses GitHub's native **Issue Types** (the repo's `Bug`/`Feature`/`Task` types, set via `gh issue edit <n> --type <name>` — not a label). `Task` exists as a third native type but isn't part of the skill's two-role model; don't use it during triage.
+
+| Role in mattpocock/skills | Issue Type in our tracker | Meaning                    |
+| --------------------------- | -------------------------- | -------------------------- |
+| `bug`                        | `Bug`                       | Something is broken        |
+| `enhancement`                 | `Feature`                   | New feature or improvement |
+
+(An earlier pass created `type/bug`/`type/enhancement` labels for this — removed the same day in favor of the native field, which already existed at the org level.)
+
+## Tech-area labels (not part of the skill's roles, but touched by the same cleanup)
+
+`tech/php`, `tech/js`, `tech/css`, `tech/twig` were collapsed into `tech/frontend` and `tech/backend` (2026-09-10). Twig templates count as `tech/frontend` (view/markup layer), even though they're PHP-rendered — group with JS/CSS, not with PHP business logic. `tech/other` is untouched. An issue can carry both when it genuinely spans the stack.
+
+## Label hygiene (2026-09-10 pass)
+
+- **One separator, `/`, everywhere.** `wayfinder:map`/`wayfinder:research`/`wayfinder:task` used `:`; renamed to `wayfinder/map` etc. to match `status/*`, `tech/*`. If a new label group gets added, use `/`.
+- **`type/help wanted` and `type/question` removed** — unused (`help wanted`) or redundant now that category lives on the native Issue Type field (`question` doesn't map to `Bug`/`Feature` anyway; use a comment instead of a label for that case).
+- **Dependabot's auto-applied labels removed**: `dependencies`, `docker`, `github_actions`, `php` (bare, not `tech/php`) only ever appeared on Dependabot PRs. Safe to delete — `.github/dependabot.yml` sets `open-pull-requests-limit: 0` on every ecosystem, so Dependabot no longer opens PRs and won't recreate them.
+
+The full current label set: `status/{needs-triage,needs-info,ready-for-agent,ready-for-human,wontfix,duplicate,in progress,to review,done}`, `tech/{frontend,backend,other}`, `wayfinder/{map,research,task}`.
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string (or, for category, the issue type) from the tables above.


### PR DESCRIPTION
## Summary
- Adds `docs/agents/` (issue tracker conventions, triage labels, domain-doc pointers) and points `AGENTS.md` at them, exempted from the `/docs/` gitignore rule as non-sensitive.
- Fixes stale dev-environment docs: `.env.local` is copied by `.worktreeinclude` as a plain file (not a symlink), and the `mariadb-dump`/`mariadb` pipe via `docker exec ... sh -c '...|...'` is blocked by a worktree-isolated session's command guard — dump to a scratch file and reload instead.
- Ignores `.playwright-mcp/`, generated by the Playwright MCP tool but not yet covered by `.gitignore`.

## Test plan
- [ ] Docs-only + gitignore changes — no functional code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdWb661i4G5M3PZtZa5rsK